### PR TITLE
Display email counts on group buttons

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -118,6 +118,9 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
             }}
           >
             {group.name}
+            <span style={{ marginLeft: '0.25rem', fontSize: '0.8rem', color: '#c8bfb7' }}>
+              ({group.emails.length})
+            </span>
           </button>
         ))}
         {(selectedGroups.length > 0 || adhocEmails.length > 0) && (

--- a/src/components/EmailGroups.test.jsx
+++ b/src/components/EmailGroups.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import EmailGroups from './EmailGroups'
+
+const sampleData = [
+  ['Group A', 'Group B'],
+  ['a1@example.com', 'b1@example.com'],
+  ['a2@example.com', '']
+]
+
+describe('EmailGroups', () => {
+  it('shows count next to group name', () => {
+    render(
+      <EmailGroups
+        emailData={sampleData}
+        adhocEmails={[]}
+        selectedGroups={[]}
+        setSelectedGroups={() => {}}
+        setAdhocEmails={() => {}}
+      />
+    )
+    expect(screen.getByRole('button', { name: /Group A \(2\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Group B \(1\)/ })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- show count of emails on each group button
- add unit test for email group counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684224a81c6c8328aee7a048e487b1ff