### PR TITLE
Fix Teams meeting link

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,3 +75,9 @@ ipcMain.on('open-excel-file', (event, filename) => {
     shell.openPath(filePath)
   }
 })
+
+ipcMain.handle('open-external-link', async (_event, url) => {
+  if (url) {
+    await shell.openExternal(url)
+  }
+})

--- a/preload.js
+++ b/preload.js
@@ -3,5 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('nocListAPI', {
   loadExcelData: () => ipcRenderer.sendSync('load-excel-data'),
   openFile: (filename) => ipcRenderer.send('open-excel-file', filename),
-  onExcelDataUpdate: (callback) => ipcRenderer.on('excel-data-updated', (_, data) => callback(data))
+  onExcelDataUpdate: (callback) => ipcRenderer.on('excel-data-updated', (_, data) => callback(data)),
+  openExternal: (url) => ipcRenderer.invoke('open-external-link', url)
 })

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -50,8 +50,8 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
 
   const launchTeams = () => {
     if (mergedEmails.length > 0) {
-      const url = `https://teams.microsoft.com/l/meeting/new?attendees=${encodeURIComponent(mergedEmails.join(';'))}`
-      window.open(url, '_blank')
+      const url = `https://teams.microsoft.com/l/meeting/new?attendees=${encodeURIComponent(mergedEmails.join(','))}`
+      window.nocListAPI?.openExternal?.(url)
     }
   }
 


### PR DESCRIPTION
## Summary
- launch Teams meeting via external link handler
- expose external link method in preload
- join attendee list with commas
- use IPC handle for async external link

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68424fdfb7c08328bc5235274fea42a0