### PR TITLE
Fix contacts search crash for numeric fields

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -8,7 +8,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
     setFiltered(
       contactData.filter(c =>
         Object.values(c).some(val =>
-          val.toLowerCase().includes(query.toLowerCase())
+          String(val).toLowerCase().includes(query.toLowerCase())
         )
       )
     )

--- a/src/components/ContactSearch.test.jsx
+++ b/src/components/ContactSearch.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect } from 'vitest'
+import ContactSearch from './ContactSearch'
+
+const contacts = [
+  { Name: 'Alice', Title: 'Agent', Email: 'alice@example.com', Phone: 12345 }
+]
+
+describe('ContactSearch', () => {
+  it('filters contacts without crashing on non-string values', () => {
+    render(
+      <ContactSearch contactData={contacts} addAdhocEmail={() => {}} />
+    )
+    const input = screen.getByPlaceholderText(/search contacts/i)
+    fireEvent.change(input, { target: { value: 'alice' } })
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- guard against non-string values when filtering contacts
- add regression test for searching contacts

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842552f37c483288ca1611e2c9861e5