### PR TITLE
Fix artifact upload step on Windows CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,15 +9,15 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - run: npm install
       - run: npx vitest run
       - run: npm run package
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NOCList-win32-x64
           path: dist/NOCList-win32-x64


### PR DESCRIPTION
## Summary
- use `actions/checkout@v4`
- use `actions/setup-node@v4`
- update upload step to `actions/upload-artifact@v4`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842714955148328b180a4efea820404