### PR TITLE
Fix Vite base path for packaged Electron app

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  root: '.'
+  root: '.',
+  base: './'
 })

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+const { defineConfig } = require('vitest/config')
+const react = require('@vitejs/plugin-react')
 
-export default defineConfig({
+module.exports = defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add `base: './'` to Vite config so the built app uses relative paths
- convert `vitest.config.js` to CommonJS so `require('vitest/config')` resolves

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684275b35e38832892a52e43a63928b8