### PR TITLE
Update packaging to output to release folder

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: NOCList-win32-x64
-          path: dist/NOCList-win32-x64
+          path: release/NOCList-win32-x64

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Build the React frontend and package the Electron app into a Windows executable:
 npm run package
 ```
 
-The generated `dist/NOCList-win32-x64` folder will contain `NOCList.exe`. Place
+The generated `release/NOCList-win32-x64` folder will contain `NOCList.exe`. Place
 `groups.xlsx` and `contacts.xlsx` next to the executable so the application can
 load them at runtime.
 
 ## Continuous Integration
 
 A GitHub Actions workflow builds the Windows package on each push to `main`.
-The resulting `NOCList-win32-x64` folder is uploaded as a workflow artifact.
+The resulting `release/NOCList-win32-x64` folder is uploaded as a workflow artifact.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=dist"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release"
   },
   "dependencies": {
     "electron": "^27.0.0",


### PR DESCRIPTION
## Summary
- update `npm run package` to use `release` output directory
- update CI workflow artifact path
- update docs for new package location

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842807bd9fc8328a94d311a31fd2770