### PR TITLE
Display ASCII logo above tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,7 +79,18 @@ function App() {
 
 return (
     <div style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}><Toaster position="top-right" toastOptions={toastOptions} />
-      <h1 style={{ fontSize: '2rem', marginBottom: '1rem' }}>NOC List</h1>
+      <pre style={{
+        fontFamily: 'monospace',
+        fontSize: '1rem',
+        marginBottom: '1rem',
+        lineHeight: '1.2',
+      }}>
+        {`    _   ______  ______   __    _      __
+   / | / / __ \/ ____/  / /   (_)____/ /_
+  /  |/ / / / / /      / /   / / ___/ __/
+ / /|  / /_/ / /___   / /___/ (__  ) /_
+/_/ |_|\____/\____/  /_____/_/____/\__/`}
+      </pre>
       <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
         <div style={{
       display: 'flex',

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -10,6 +10,8 @@ describe('App', () => {
       onExcelDataUpdate: () => {},
     }
     render(<App />)
-    expect(screen.getByText(/NOC List/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/_\s+______\s+______\s+__\s+_/)
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- show NOC List ASCII art above the tabs in the app
- update test to look for the ASCII banner

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843281c5f548328b302f9cc5ec9f81c