### PR TITLE
Improve responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,8 +92,9 @@ return (
 /_/ |_|\____/\____/  /_____/_/____/\__/`}
       </pre>
       <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-        <div style={{
-      display: 'flex',
+      <div
+        className="stack-on-small"
+        style={{
       gap: '2rem',
       borderBottom: '1px solid var(--border-color)',
       paddingBottom: '0.5rem',
@@ -127,7 +128,9 @@ return (
     </div>
       </div>
 
-      <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+      <div
+        className="stack-on-small"
+        style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}>
 
 <button
           onClick={refreshData}

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -16,7 +16,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
 
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
+      <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
         <input
           type="text"
           placeholder="Search contacts..."

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -66,7 +66,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
         </button>
       </div>
 
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1.5rem', gap: '0.5rem' }}>
+      <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1.5rem', gap: '0.5rem' }}>
         <input
           type="text"
           placeholder="Search groups..."

--- a/src/theme.css
+++ b/src/theme.css
@@ -41,3 +41,15 @@ body {
   background-color: #222;
   color: var(--text-light);
 }
+
+/* Utility class to stack flex children on narrow screens */
+.stack-on-small {
+  display: flex;
+}
+
+@media (max-width: 600px) {
+  .stack-on-small {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add `stack-on-small` utility class for responsive layout
- use new class in main layout and search bars

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68432b90930c8328b182f9b06e7de624