### PR TITLE
Fix search bar layout

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -34,7 +34,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
   return (
     <div>
       <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
-        <div style={{ position: 'relative', width: '100%', maxWidth: '300px' }}>
+        <div style={{ position: 'relative', flex: '1 1 250px', maxWidth: '300px' }}>
           <input
             type="text"
             placeholder="Search contacts..."

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -67,7 +67,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
       </div>
 
       <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1.5rem', gap: '0.5rem' }}>
-        <div style={{ position: 'relative', width: '100%', maxWidth: '300px' }}>
+        <div style={{ position: 'relative', flex: '1 1 250px', maxWidth: '300px' }}>
           <input
             type="text"
             placeholder="Search groups..."

--- a/src/theme.css
+++ b/src/theme.css
@@ -89,6 +89,7 @@ body {
 /* Utility class to stack flex children on narrow screens */
 .stack-on-small {
   display: flex;
+  flex-wrap: wrap;
 }
 
 @media (max-width: 450px) {


### PR DESCRIPTION
## Summary
- reposition clear button
- flexibly size search inputs to stop overlap

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68435afb83b483288e9b709600e46d23