### PR TITLE
Fix clear button alignment

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -56,6 +56,8 @@ body {
   right: 0.25rem;
   top: 50%;
   transform: translateY(-50%);
+  padding: 0;
+  line-height: 1;
   opacity: 0.8;
   transition: opacity 0.2s ease, transform 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- adjust CSS for `.clear-btn` so it sits flush against the right edge of the search bar

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843692d70d08328beec356001f51166