### PR TITLE
Improve search bar spacing and card layout

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -50,7 +50,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
             value={query}
             onChange={e => setQuery(e.target.value)}
             className="input"
-            style={{ width: '100%', paddingRight: '2rem', borderRadius: '6px' }}
+            style={{ width: '100%', paddingRight: '2.25rem', borderRadius: '6px' }}
           />
           {query && (
             <button
@@ -68,7 +68,8 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 300px))',
+            justifyContent: 'start',
             gap: '1rem'
           }}
         >

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -74,7 +74,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
             value={search}
             onChange={e => setSearch(e.target.value)}
             className="input"
-            style={{ width: '100%', paddingRight: '1.5rem' }}
+            style={{ width: '100%', paddingRight: '1.75rem' }}
           />
           {search && (
             <button

--- a/src/theme.css
+++ b/src/theme.css
@@ -54,7 +54,7 @@ body {
   cursor: pointer;
   font-size: 1rem;
   position: absolute;
-  right: 0.25rem;
+  right: 0.5rem;
   top: 50%;
   transform: translateY(-50%);
   padding: 0;


### PR DESCRIPTION
## Summary
- tweak `.clear-btn` spacing
- update padding for search inputs
- prevent contact cards from stretching when only one is shown

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68436db3596c8328b3f76baf9e9bd5c4