### PR TITLE
Finalize animations and toast styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,30 +55,32 @@ function App() {
   }, [tab])
 
   const toastOptions = {
-  style: {
-    background: '#2e261f',
-    color: '#f4f1ee',
-    border: '1px solid #59493f',
-    fontSize: '0.9rem',
-  },
-  success: {
-    icon: '',
     style: {
-      background: '#334033',
-      color: '#d0f0d0',
+      background: 'var(--bg-secondary)',
+      color: 'var(--text-light)',
+      border: '1px solid var(--border-color)',
+      fontSize: '0.9rem',
+      borderRadius: '6px',
+      fontFamily: 'DM Sans, sans-serif',
     },
-  },
-  error: {
-    icon: '',
-    style: {
-      background: '#402e2e',
-      color: '#f4d0d0',
+    success: {
+      icon: '',
+      style: {
+        background: '#334033',
+        color: '#d0f0d0',
+      },
     },
-  },
-};
+    error: {
+      icon: '',
+      style: {
+        background: '#402e2e',
+        color: '#f4d0d0',
+      },
+    },
+  };
 
 return (
-    <div style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}><Toaster position="top-right" toastOptions={toastOptions} />
+    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}><Toaster position="top-right" toastOptions={toastOptions} />
       <pre style={{
         fontFamily: 'monospace',
         fontSize: '1rem',

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { toast } from 'react-hot-toast'
 
 const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups, setAdhocEmails }) => {
   const [mergedEmails, setMergedEmails] = useState([])
@@ -45,6 +46,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
       navigator.clipboard.writeText(mergedEmails.join(', '))
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
+      toast.success('Email list copied to clipboard')
     }
   }
 
@@ -52,6 +54,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
     if (mergedEmails.length > 0) {
       const url = `https://teams.microsoft.com/l/meeting/new?attendees=${encodeURIComponent(mergedEmails.join(','))}`
       window.nocListAPI?.openExternal?.(url)
+      toast.success('Opening Teams meeting')
     }
   }
 
@@ -93,7 +96,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
           <button
             key={group.name}
             onClick={() => toggleSelect(group.name)}
-            className="btn"
+            className="btn fade-in"
             style={{
               background: selectedGroups.includes(group.name) ? 'var(--accent)' : '#444'
             }}
@@ -105,7 +108,7 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
           </button>
         ))}
         {(selectedGroups.length > 0 || adhocEmails.length > 0) && (
-          <button onClick={clearAll} className="btn btn-secondary">
+          <button onClick={clearAll} className="btn btn-secondary fade-in">
             Clear All
           </button>
         )}
@@ -114,10 +117,10 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
       {mergedEmails.length > 0 && (
         <>
           <div style={{ marginBottom: '0.5rem', display: 'flex', gap: '0.5rem' }}>
-            <button onClick={copyToClipboard} className="btn">
+            <button onClick={copyToClipboard} className="btn fade-in">
               Copy Email List
             </button>
-            <button onClick={launchTeams} className="btn btn-secondary">
+            <button onClick={launchTeams} className="btn btn-secondary fade-in">
               Start Teams Meeting
             </button>
             {copied && <span style={{ color: 'lightgreen', alignSelf: 'center' }}>Copied</span>}

--- a/src/theme.css
+++ b/src/theme.css
@@ -23,11 +23,12 @@ body {
   background: var(--button-bg);
   color: var(--text-light);
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .btn:hover {
   background: var(--accent);
+  transform: translateY(-2px);
 }
 
 .btn-secondary {
@@ -91,6 +92,10 @@ body {
   to {
     opacity: 1;
   }
+}
+
+.fade-in {
+  animation: fade-in 0.3s ease;
 }
 
 /* Utility class to stack flex children on narrow screens */


### PR DESCRIPTION
## Summary
- improve button transitions and add reusable fade-in animation
- make toast notifications use theme colors
- animate main layout and email group controls
- show toast when copying email list or launching a meeting

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68437032a5c08328bd7e3caf92ec1159