### PR TITLE
Enable custom logo and icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Vitest is used for unit testing. To run the test suite:
 npm test
 ```
 
+## Custom Logo and Icon
+
+To replace the ASCII logo shown in the app, add a `logo.png` file to the
+`public` folder. If the file exists it will be displayed instead of the
+text banner.
+
+For a custom application icon, provide `icon.png` for use at runtime and an
+`icon.ico` file for packaging. The packaging script automatically includes the
+ICO file when present.
+
 ## Packaging
 
 Build the React frontend and package the Electron app into a Windows executable:
@@ -39,6 +49,9 @@ npm run package
 The generated `release/NOCList-win32-x64` folder will contain `NOCList.exe`. Place
 `groups.xlsx` and `contacts.xlsx` next to the executable so the application can
 load them at runtime.
+
+If `icon.ico` exists in the project root it will be used as the Windows
+application icon.
 
 ## Continuous Integration
 

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ function createWindow() {
   win = new BrowserWindow({
     width: 1000,
     height: 800,
+    icon: path.join(basePath, 'icon.png'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=icon.ico"
   },
   "dependencies": {
     "electron": "^27.0.0",

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,1 @@
+Place your custom logo.png in this folder. It will be copied into the packaged build.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,12 +10,21 @@ function App() {
   const [contactData, setContactData] = useState([])
   const [lastRefresh, setLastRefresh] = useState('N/A')
   const [tab, setTab] = useState(() => localStorage.getItem('activeTab') || 'email')
+  const [logoAvailable, setLogoAvailable] = useState(false)
 
   useEffect(() => {
     const { emailData, contactData } = window.nocListAPI.loadExcelData()
     setEmailData(emailData)
     setContactData(contactData)
     setLastRefresh(new Date().toLocaleString())
+  }, [])
+
+  useEffect(() => {
+    fetch('logo.png', { method: 'HEAD' })
+      .then((res) => {
+        if (res.ok) setLogoAvailable(true)
+      })
+      .catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -79,20 +88,24 @@ function App() {
     },
   };
 
-return (
+  return (
     <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}><Toaster position="top-right" toastOptions={toastOptions} />
-      <pre style={{
-        fontFamily: 'monospace',
-        fontSize: '1rem',
-        marginBottom: '1rem',
-        lineHeight: '1.2',
-      }}>
-        {`    _   ______  ______   __    _      __
+      {logoAvailable ? (
+        <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
+      ) : (
+        <pre style={{
+          fontFamily: 'monospace',
+          fontSize: '1rem',
+          marginBottom: '1rem',
+          lineHeight: '1.2',
+        }}>
+          {`    _   ______  ______   __    _      __
    / | / / __ \/ ____/  / /   (_)____/ /_
   /  |/ / / / / /      / /   / / ___/ __/
  / /|  / /_/ / /___   / /___/ (__  ) /_
 /_/ |_|\____/\____/  /_____/_/____/\__/`}
-      </pre>
+        </pre>
+      )}
       <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
       <div
         className="stack-on-small"

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import App from './App'
 
 describe('App', () => {
   it('renders heading', () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false }))
     window.nocListAPI = {
       loadExcelData: () => ({ emailData: [], contactData: [] }),
       onExcelDataUpdate: () => {},
@@ -13,5 +14,15 @@ describe('App', () => {
     expect(
       screen.getByText(/_\s+______\s+______\s+__\s+_/)
     ).toBeInTheDocument()
+  })
+
+  it('shows image when logo file is available', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true }))
+    window.nocListAPI = {
+      loadExcelData: () => ({ emailData: [], contactData: [] }),
+      onExcelDataUpdate: () => {},
+    }
+    render(<App />)
+    expect(await screen.findByAltText('NOC List Logo')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- support PNG logo if `public/logo.png` exists
- use custom app icon when present
- document how to add custom logo/icon
- update tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68437a78ed308328bb51f894c5f8476f