### PR TITLE
Fix icon path for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To replace the ASCII logo shown in the app, add a `logo.png` file to the
 `public` folder. If the file exists it will be displayed instead of the
 text banner.
 
-For a custom application icon, provide `icon.png` for use at runtime and an
-`icon.ico` file for packaging. The packaging script automatically includes the
+For a custom application icon, place `icon.png` and `icon.ico` in the
+`public` folder. The packaging script automatically includes the
 ICO file when present.
 
 ## Packaging
@@ -50,7 +50,7 @@ The generated `release/NOCList-win32-x64` folder will contain `NOCList.exe`. Pla
 `groups.xlsx` and `contacts.xlsx` next to the executable so the application can
 load them at runtime.
 
-If `icon.ico` exists in the project root it will be used as the Windows
+If `public/icon.ico` exists it will be used as the Windows
 application icon.
 
 ## Continuous Integration

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=icon.ico"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico"
   },
   "dependencies": {
     "electron": "^27.0.0",


### PR DESCRIPTION
## Summary
- use `public/icon.ico` when packaging
- clarify icon path in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438a9671688328bba6cefdab4bab70