### PR TITLE
Enhance contact card styling

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -74,11 +74,16 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
           {filtered.map((contact, i) => (
             <div key={i} className="contact-card">
               <strong>{contact.Name}</strong>
-              <p style={{ margin: '0.5rem 0 0 0' }}>{contact.Title}</p>
+              <p style={{ margin: '0.5rem 0 0 0' }}>
+                <span className="label">Title:</span> {contact.Title}
+              </p>
               <p style={{ margin: 0 }}>
+                <span className="label">Email:</span>{' '}
                 <a href={`mailto:${contact.Email}`}>{contact.Email}</a>
               </p>
-              <p style={{ margin: 0 }}>{formatPhones(contact.Phone)}</p>
+              <p style={{ margin: 0 }}>
+                <span className="label">Phone:</span> {formatPhones(contact.Phone)}
+              </p>
               <button
                 onClick={() => addAdhocEmail(contact.Email)}
                 className="btn"

--- a/src/theme.css
+++ b/src/theme.css
@@ -24,11 +24,14 @@ body {
   background: var(--button-bg);
   color: var(--text-dark);
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
+  font-weight: 500;
+  font-family: 'DM Sans', sans-serif;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
 }
 
 .btn:hover {
   background: var(--accent);
+  color: var(--text-light);
   transform: translateY(-2px);
 }
 
@@ -79,6 +82,12 @@ body {
   color: var(--text-light);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   animation: fade-in 0.3s ease;
+}
+
+.label {
+  font-weight: 600;
+  color: var(--accent);
+  margin-right: 0.25rem;
 }
 
 .contact-card:hover {


### PR DESCRIPTION
## Summary
- show Title, Email and Phone labels on contact cards
- modernize button text styling and hover behavior
- add reusable `.label` style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438c5e2df48328ac49197a70b92e43