### PR TITLE
Improve UI colors

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -96,7 +96,8 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
             onClick={() => toggleSelect(group.name)}
             className="btn fade-in"
             style={{
-              background: selectedGroups.includes(group.name) ? 'var(--accent)' : '#444'
+              background: selectedGroups.includes(group.name) ? 'var(--accent)' : '#444',
+              color: 'var(--text-light)'
             }}
           >
             {group.name}

--- a/src/theme.css
+++ b/src/theme.css
@@ -84,6 +84,16 @@ body {
   animation: fade-in 0.3s ease;
 }
 
+.contact-card strong {
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.contact-card p {
+  color: var(--text-light);
+}
+
 .label {
   font-weight: 600;
   color: var(--accent);


### PR DESCRIPTION
## Summary
- tweak contact card styling for better cohesion
- ensure email group buttons use light text on dark background

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438e24abe88328b1fd72bd9fb4e546