### PR TITLE
Improve contact readability and meeting title

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -50,7 +50,10 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
 
   const launchTeams = () => {
     if (mergedEmails.length > 0) {
-      const url = `https://teams.microsoft.com/l/meeting/new?attendees=${encodeURIComponent(mergedEmails.join(','))}`
+      const now = new Date()
+      const title = `${now.getMonth() + 1}/${now.getDate()}`
+      const url =
+        `https://teams.microsoft.com/l/meeting/new?subject=${encodeURIComponent(title)}&attendees=${encodeURIComponent(mergedEmails.join(','))}`
       window.nocListAPI?.openExternal?.(url)
       toast.success('Opening Teams meeting')
     }

--- a/src/theme.css
+++ b/src/theme.css
@@ -4,7 +4,7 @@
   --text-light: #f4f1ee;
   --text-muted: #aaa;
   --text-dark: #1e1b18;
-  --accent: #82614f;
+  --accent: #d2a679;
   --button-bg: #88d4c4;
   --button-secondary: #5e3b2c;
   --border-color: #59493f;


### PR DESCRIPTION
## Summary
- tweak accent color for better readability on contact cards
- include current date in Teams meeting title

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438f789d348328a6334eef1ce03bb3