### PR TITLE
Update mailto style and toasts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,15 +75,15 @@ function App() {
     success: {
       icon: '',
       style: {
-        background: '#334033',
-        color: '#d0f0d0',
+        background: 'var(--accent)',
+        color: 'var(--text-dark)',
       },
     },
     error: {
       icon: '',
       style: {
-        background: '#402e2e',
-        color: '#f4d0d0',
+        background: 'var(--button-secondary)',
+        color: 'var(--text-light)',
       },
     },
   };

--- a/src/theme.css
+++ b/src/theme.css
@@ -134,18 +134,11 @@ body {
 
 /* Mailto link styling */
 a[href^="mailto:"] {
-  color: var(--accent);
+  color: var(--text-light);
   text-decoration: none;
-  font-weight: 600;
-  border-bottom: 1px solid var(--accent);
-  padding: 0 0.15rem;
-  border-radius: 2px;
-  word-break: break-all;
-  overflow-wrap: anywhere;
 }
 
 a[href^="mailto:"]:hover {
-  background-color: var(--accent);
-  color: var(--text-light);
-  border-bottom-color: var(--text-light);
+  color: var(--accent);
+  text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- tone down mailto link color so it matches phone and title text
- use themed colors for toast notifications

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684390cf2fcc8328b1203bd964def531