### PR TITLE
Delay showing Electron window until ready

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@ function createWindow() {
     width: 1000,
     height: 800,
     icon: path.join(basePath, 'icon.png'),
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -46,6 +47,10 @@ function createWindow() {
   } else {
     win.loadURL('http://localhost:5173/')
   }
+
+  win.once('ready-to-show', () => {
+    win.show()
+  })
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- avoid flicker by hiding the window until `ready-to-show`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684391e2afc8832890c2de81f1eb54d5