### PR TITLE
Refine button and toast colors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,15 +75,15 @@ function App() {
     success: {
       icon: '',
       style: {
-        background: 'var(--accent)',
+        background: 'var(--button-bg)',
         color: 'var(--text-dark)',
       },
     },
     error: {
       icon: '',
       style: {
-        background: 'var(--button-secondary)',
-        color: 'var(--text-light)',
+        background: 'var(--button-bg)',
+        color: 'var(--text-dark)',
       },
     },
   };

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -99,8 +99,10 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
             onClick={() => toggleSelect(group.name)}
             className="btn fade-in"
             style={{
-              background: selectedGroups.includes(group.name) ? 'var(--accent)' : '#444',
-              color: 'var(--text-light)'
+              background: selectedGroups.includes(group.name)
+                ? 'var(--button-hover)'
+                : 'var(--button-bg)',
+              color: 'var(--text-dark)'
             }}
           >
             {group.name}

--- a/src/theme.css
+++ b/src/theme.css
@@ -5,8 +5,9 @@
   --text-muted: #aaa;
   --text-dark: #1e1b18;
   --accent: #d2a679;
-  --button-bg: #88d4c4;
-  --button-secondary: #5e3b2c;
+  --button-bg: var(--accent);
+  --button-secondary: var(--accent);
+  --button-hover: #e6ba8d;
   --border-color: #59493f;
 }
 
@@ -30,14 +31,14 @@ body {
 }
 
 .btn:hover {
-  background: var(--accent);
-  color: var(--text-light);
+  background: var(--button-hover);
+  color: var(--text-dark);
   transform: translateY(-2px);
 }
 
 .btn-secondary {
   background: var(--button-secondary);
-  color: var(--text-light);
+  color: var(--text-dark);
 }
 
 .open-contact-btn {


### PR DESCRIPTION
## Summary
- unify button colors with theme accent
- apply consistent colors to group buttons
- standardize success and error toast colors

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684398daefe4832881f0682d414f82a5