### PR TITLE
Add rotating security code

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,13 +11,26 @@ function App() {
   const [lastRefresh, setLastRefresh] = useState('N/A')
   const [tab, setTab] = useState(() => localStorage.getItem('activeTab') || 'email')
   const [logoAvailable, setLogoAvailable] = useState(false)
+  const [currentCode, setCurrentCode] = useState('')
+  const [previousCode, setPreviousCode] = useState('')
+
+  const generateCode = () => Math.floor(10000 + Math.random() * 90000).toString()
 
   useEffect(() => {
     const { emailData, contactData } = window.nocListAPI.loadExcelData()
     setEmailData(emailData)
     setContactData(contactData)
     setLastRefresh(new Date().toLocaleString())
+    setCurrentCode(generateCode())
   }, [])
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPreviousCode(currentCode)
+      setCurrentCode(generateCode())
+    }, 5 * 60 * 1000)
+    return () => clearInterval(interval)
+  }, [currentCode])
 
   useEffect(() => {
     fetch('logo.png', { method: 'HEAD' })
@@ -89,7 +102,12 @@ function App() {
   };
 
   return (
-    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}><Toaster position="top-right" toastOptions={toastOptions} />
+    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}>
+      <Toaster position="top-right" toastOptions={toastOptions} />
+      <div style={{ position: 'fixed', top: '1rem', right: '1rem', background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '0.5rem 1rem', textAlign: 'center', fontSize: '0.9rem' }}>
+        <div>Code: {currentCode}</div>
+        <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Prev: {previousCode || 'N/A'}</div>
+      </div>
       {logoAvailable ? (
         <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
       ) : (


### PR DESCRIPTION
## Summary
- generate a 5-digit security code every 5 minutes
- show the current and previous code in a fixed box

## Testing
- `npm test -- -w=false`

------
https://chatgpt.com/codex/tasks/task_e_6853174321f0832895a10d8b12f06d8e