### PR TITLE
Add timer progress bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ function App() {
   const [logoAvailable, setLogoAvailable] = useState(false)
   const [currentCode, setCurrentCode] = useState('')
   const [previousCode, setPreviousCode] = useState('')
+  const [progressKey, setProgressKey] = useState(Date.now())
 
   const generateCode = () => Math.floor(10000 + Math.random() * 90000).toString()
 
@@ -22,12 +23,14 @@ function App() {
     setContactData(contactData)
     setLastRefresh(new Date().toLocaleString())
     setCurrentCode(generateCode())
+    setProgressKey(Date.now())
   }, [])
 
   useEffect(() => {
     const interval = setInterval(() => {
       setPreviousCode(currentCode)
       setCurrentCode(generateCode())
+      setProgressKey(Date.now())
     }, 5 * 60 * 1000)
     return () => clearInterval(interval)
   }, [currentCode])
@@ -107,6 +110,9 @@ function App() {
       <div style={{ position: 'fixed', top: '1rem', right: '1rem', background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '0.5rem 1rem', textAlign: 'center', fontSize: '0.9rem' }}>
         <div>Code: {currentCode}</div>
         <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Prev: {previousCode || 'N/A'}</div>
+        <div className="progress-container">
+          <div key={progressKey} className="progress-bar" />
+        </div>
       </div>
       {logoAvailable ? (
         <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />

--- a/src/theme.css
+++ b/src/theme.css
@@ -187,3 +187,32 @@ body::-webkit-scrollbar-thumb {
   background-color: var(--accent);
   border-radius: 4px;
 }
+
+/* Progress bar for code timer */
+.progress-container {
+  position: relative;
+  width: 100%;
+  height: 4px;
+  background: var(--bg-primary);
+  margin-top: 0.25rem;
+  overflow: hidden;
+  border-radius: 2px;
+}
+
+.progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: var(--accent);
+  animation: code-progress 300s linear forwards;
+}
+
+@keyframes code-progress {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- show a progress bar that counts down the 5 minute code refresh
- restart the progress animation whenever the code changes

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68531a6d90bc8328ad337795ee000604