### PR TITLE
Improve efficiency and cleanup

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const xlsx = require('xlsx')
 const basePath = app.isPackaged ? path.dirname(process.execPath) : __dirname
 
 let win
+let watcher
 let cachedData = { emailData: [], contactData: [] }
 
 function loadExcelFiles() {
@@ -61,7 +62,7 @@ app.whenReady().then(() => {
   const groupsPath = path.join(basePath, 'groups.xlsx')
   const contactsPath = path.join(basePath, 'contacts.xlsx')
 
-  const watcher = chokidar.watch([groupsPath, contactsPath], {
+  watcher = chokidar.watch([groupsPath, contactsPath], {
     persistent: true,
     ignoreInitial: true,
   })
@@ -82,6 +83,12 @@ app.whenReady().then(() => {
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
+})
+
+app.on('will-quit', () => {
+  if (watcher) {
+    watcher.close()
+  }
 })
 
 ipcMain.on('load-excel-data', (event) => {

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -19,15 +19,14 @@ const formatPhones = (value) => {
 
 const ContactSearch = ({ contactData, addAdhocEmail }) => {
   const [query, setQuery] = useState('')
-  const filtered = useMemo(
-    () =>
-      contactData.filter(c =>
-        Object.values(c).some(val =>
-          String(val).toLowerCase().includes(query.toLowerCase())
-        )
-      ),
-    [query, contactData]
-  )
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase()
+    return contactData.filter((c) =>
+      Object.values(c).some((val) =>
+        String(val).toLowerCase().includes(q)
+      )
+    )
+  }, [query, contactData])
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- cleanup watchers and close on quit
- refactor React components using hooks for performance
- streamline contact search filtering
- add async clipboard handling and caching in EmailGroups
- reuse memoized toast options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535d8750648328a5400d56a10355fd