### PR TITLE
chore: align start script error logging after merging main

### DIFF
--- a/start-app.js
+++ b/start-app.js
@@ -57,7 +57,7 @@ async function start() {
       shutdown()
     })
   } catch (err) {
-    console.error(`❌ Failed to detect Vite dev server: ${err.message}`)
+    console.error('❌ Failed to detect Vite dev server:', err.message)
     vite.kill('SIGINT')
     process.exit(1)
   }


### PR DESCRIPTION
## Summary
- align start-app error logging style with upstream
- integrate latest main changes

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6896596a317883288055c6c712ec1ad3