### PR TITLE
Refine modules with documentation and hooks

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,8 +1,31 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
+/**
+ * Safely expose a minimal API surface to the renderer process.
+ */
 contextBridge.exposeInMainWorld('nocListAPI', {
+  /**
+   * Load Excel data synchronously from the main process.
+   * @returns {{emailData: any[], contactData: any[]}}
+   */
   loadExcelData: () => ipcRenderer.sendSync('load-excel-data'),
+
+  /**
+   * Ask the main process to open an Excel file.
+   * @param {string} filename
+   */
   openFile: (filename) => ipcRenderer.send('open-excel-file', filename),
-  onExcelDataUpdate: (callback) => ipcRenderer.on('excel-data-updated', (_, data) => callback(data)),
-  openExternal: (url) => ipcRenderer.invoke('open-external-link', url)
+
+  /**
+   * Listen for automatic Excel data updates.
+   * @param {(data: {emailData: any[], contactData: any[]}) => void} callback
+   */
+  onExcelDataUpdate: (callback) =>
+    ipcRenderer.on('excel-data-updated', (_, data) => callback(data)),
+
+  /**
+   * Open an external URL in the user's default browser.
+   * @param {string} url
+   */
+  openExternal: (url) => ipcRenderer.invoke('open-external-link', url),
 })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react'
+import React, { useEffect, useState, useCallback, useMemo } from 'react'
 import EmailGroups from './components/EmailGroups'
 import ContactSearch from './components/ContactSearch'
+import CodeDisplay from './components/CodeDisplay'
+import TabSelector from './components/TabSelector'
 import { Toaster, toast } from 'react-hot-toast'
+import useRotatingCode from './hooks/useRotatingCode'
 
 function App() {
   const [selectedGroups, setSelectedGroups] = useState([])
@@ -11,40 +14,21 @@ function App() {
   const [lastRefresh, setLastRefresh] = useState('N/A')
   const [tab, setTab] = useState(() => localStorage.getItem('activeTab') || 'email')
   const [logoAvailable, setLogoAvailable] = useState(false)
-  const [currentCode, setCurrentCode] = useState('')
-  const [previousCode, setPreviousCode] = useState('')
-  const [progressKey, setProgressKey] = useState(Date.now())
-
-  const generateCode = useCallback(
-    () => Math.floor(10000 + Math.random() * 90000).toString(),
-    []
-  )
+  const { currentCode, previousCode, progressKey } = useRotatingCode()
 
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-  const codeRef = useRef('')
-
-  useEffect(() => {
+  /** Load group and contact data from the preloaded Excel files. */
+  const loadData = useCallback(() => {
     const { emailData, contactData } = window.nocListAPI.loadExcelData()
     setEmailData(emailData)
     setContactData(contactData)
     setLastRefresh(new Date().toLocaleString())
-    const newCode = generateCode()
-    codeRef.current = newCode
-    setCurrentCode(newCode)
-    setProgressKey(Date.now())
   }, [])
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setPreviousCode(codeRef.current)
-      const newCode = generateCode()
-      codeRef.current = newCode
-      setCurrentCode(newCode)
-      setProgressKey(Date.now())
-    }, 5 * 60 * 1000)
-    return () => clearInterval(interval)
-  }, [])
+    loadData()
+  }, [loadData])
 
   useEffect(() => {
     fetch('logo.png', { method: 'HEAD' })
@@ -65,17 +49,16 @@ function App() {
     }
   }, [])
 
+  /** Manually refresh Excel data and clear any ad-hoc emails. */
   const refreshData = useCallback(() => {
-    const { emailData, contactData } = window.nocListAPI.loadExcelData()
-    setEmailData(emailData)
-    setContactData(contactData)
-    setLastRefresh(new Date().toLocaleString())
+    loadData()
     setAdhocEmails([])
     toast.success('Data refreshed')
-  }, [])
+  }, [loadData])
 
   const isValidEmail = useCallback((email) => emailRegex.test(email), [])
 
+  /** Add a user-provided email to the current ad-hoc list if valid. */
   const addAdhocEmail = useCallback(
     (email) => {
       if (isValidEmail(email)) {
@@ -85,7 +68,7 @@ function App() {
         toast.error('Invalid email address')
       }
     },
-    [isValidEmail]
+    [isValidEmail],
   )
 
   useEffect(() => {
@@ -117,83 +100,50 @@ function App() {
         },
       },
     }),
-    []
+    [],
   )
 
   return (
-    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}>
+    <div
+      className="fade-in"
+      style={{
+        fontFamily: 'DM Sans, sans-serif',
+        background: 'var(--bg-primary)',
+        color: 'var(--text-light)',
+        minHeight: '100vh',
+        padding: '2rem',
+      }}
+    >
       <Toaster position="top-right" toastOptions={toastOptions} />
-      <div style={{ position: 'fixed', top: '1rem', right: '1rem', background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '0.5rem 1rem', textAlign: 'center', fontSize: '0.9rem' }}>
-        <div style={{ fontSize: '1.6rem', fontWeight: 'bold' }}>Code: {currentCode}</div>
-        <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Prev: {previousCode || 'N/A'}</div>
-        <div className="progress-container">
-          <div key={progressKey} className="progress-bar" />
-        </div>
-      </div>
+      <CodeDisplay currentCode={currentCode} previousCode={previousCode} progressKey={progressKey} />
       {logoAvailable ? (
         <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
       ) : (
-        <pre style={{
-          fontFamily: 'monospace',
-          fontSize: '1rem',
-          marginBottom: '1rem',
-          lineHeight: '1.2',
-        }}>
-          {`    _   ______  ______   __    _      __
-   / | / / __ \/ ____/  / /   (_)____/ /_
+        <pre
+          style={{
+            fontFamily: 'monospace',
+            fontSize: '1rem',
+            marginBottom: '1rem',
+            lineHeight: '1.2',
+          }}
+        >{`    _   ______  ______   __    _      __
+   / | / / __ \\/ ____/  / /   (_)____/ /_
   /  |/ / / / / /      / /   / / ___/ __/
  / /|  / /_/ / /___   / /___/ (__  ) /_
-/_/ |_|\____/\____/  /_____/_/____/\__/`}
-        </pre>
+/_/ |_|\\____/\\____/  /_____/_/____/\\__/`}</pre>
       )}
-      <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-      <div
-        className="stack-on-small"
-        style={{
-      gap: '2rem',
-      borderBottom: '1px solid var(--border-color)',
-      paddingBottom: '0.5rem',
-      marginBottom: '1.5rem',
-      fontSize: '1.05rem'
-    }}>
-      <div
-        onClick={() => setTab('email')}
-        style={{
-          cursor: 'pointer',
-          paddingBottom: '0.25rem',
-          borderBottom: tab === 'email' ? '3px solid var(--accent)' : '3px solid transparent',
-          color: tab === 'email' ? 'var(--text-light)' : 'var(--text-muted)',
-          fontWeight: tab === 'email' ? 'bold' : 'normal'
-        }}
-      >
-        Email Groups
-      </div>
-      <div
-        onClick={() => setTab('contact')}
-        style={{
-          cursor: 'pointer',
-          paddingBottom: '0.25rem',
-          borderBottom: tab === 'contact' ? '3px solid var(--accent)' : '3px solid transparent',
-          color: tab === 'contact' ? 'var(--text-light)' : 'var(--text-muted)',
-          fontWeight: tab === 'contact' ? 'bold' : 'normal'
-        }}
-      >
-        Contact Search
-      </div>
-    </div>
-      </div>
+      <TabSelector tab={tab} setTab={setTab} />
 
       <div
         className="stack-on-small"
-        style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}>
-
-<button
-          onClick={refreshData}
-          className="btn"
-        >
+        style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}
+      >
+        <button onClick={refreshData} className="btn">
           Refresh Data
         </button>
-        <span style={{ alignSelf: 'center', fontSize: '0.9rem' }}>Last Refreshed: {lastRefresh}</span>
+        <span style={{ alignSelf: 'center', fontSize: '0.9rem' }}>
+          Last Refreshed: {lastRefresh}
+        </span>
       </div>
 
       {tab === 'email' ? (
@@ -205,10 +155,7 @@ function App() {
           setAdhocEmails={setAdhocEmails}
         />
       ) : (
-        <ContactSearch
-          contactData={contactData}
-          addAdhocEmail={addAdhocEmail}
-        />
+        <ContactSearch contactData={contactData} addAdhocEmail={addAdhocEmail} />
       )}
     </div>
   )

--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+/**
+ * Displays the current one-time code and a progress bar indicating
+ * remaining validity time.
+ * @param {Object} props
+ * @param {string} props.currentCode
+ * @param {string} props.previousCode
+ * @param {number} props.progressKey - Forces animation restart when code updates.
+ */
+const CodeDisplay = ({ currentCode, previousCode, progressKey }) => (
+  <div
+    style={{
+      position: 'fixed',
+      top: '1rem',
+      right: '1rem',
+      background: 'var(--bg-secondary)',
+      border: '1px solid var(--border-color)',
+      borderRadius: '4px',
+      padding: '0.5rem 1rem',
+      textAlign: 'center',
+      fontSize: '0.9rem'
+    }}
+  >
+    <div style={{ fontSize: '1.6rem', fontWeight: 'bold' }}>
+      Code: {currentCode}
+    </div>
+    <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>
+      Prev: {previousCode || 'N/A'}
+    </div>
+    <div className="progress-container">
+      <div key={progressKey} className="progress-bar" />
+    </div>
+  </div>
+)
+
+export default CodeDisplay

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -1,22 +1,12 @@
 import React, { useState, useMemo } from 'react'
+import { formatPhones } from '../utils/formatPhones'
 
-const formatPhones = (value) => {
-  if (value === undefined || value === null) return ''
-  return String(value)
-    .split(/[\\/;,]+/)
-    .map((num) => num.trim())
-    .filter(Boolean)
-    .map((num) => {
-      const digits = num.replace(/\D/g, '')
-      if (!digits) return ''
-      const country = digits.length > 10 ? digits.slice(0, digits.length - 10) : '1'
-      const local = digits.slice(-10)
-      return `+${country} ${local}`
-    })
-    .filter(Boolean)
-    .join(', ')
-}
-
+/**
+ * Provide a searchable list of contacts with quick email adding.
+ * @param {Object} props
+ * @param {Array} props.contactData - Parsed contact rows.
+ * @param {(email: string) => void} props.addAdhocEmail - Callback to add emails.
+ */
 const ContactSearch = ({ contactData, addAdhocEmail }) => {
   const [query, setQuery] = useState('')
   const filtered = useMemo(() => {

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -1,7 +1,22 @@
 import React, { useMemo, useState, useCallback } from 'react'
 import { toast } from 'react-hot-toast'
 
-const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups, setAdhocEmails }) => {
+/**
+ * Manage selection of email groups and creation of merged mailing lists.
+ * @param {Object} props
+ * @param {Array} props.emailData - Raw group data from Excel.
+ * @param {string[]} props.adhocEmails - Manually added emails.
+ * @param {string[]} props.selectedGroups - Currently selected group names.
+ * @param {Function} props.setSelectedGroups - Setter for group selection.
+ * @param {Function} props.setAdhocEmails - Setter for ad-hoc emails.
+ */
+const EmailGroups = ({
+  emailData,
+  adhocEmails,
+  selectedGroups,
+  setSelectedGroups,
+  setAdhocEmails,
+}) => {
   const [copied, setCopied] = useState(false)
   const [search, setSearch] = useState('')
 

--- a/src/components/TabSelector.jsx
+++ b/src/components/TabSelector.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+/**
+ * Renders the Email/Contact tab selector.
+ * @param {Object} props
+ * @param {'email'|'contact'} props.tab - Currently active tab.
+ * @param {(tab: string) => void} props.setTab - Update active tab.
+ */
+const TabSelector = ({ tab, setTab }) => (
+  <div
+    className="stack-on-small"
+    style={{
+      gap: '2rem',
+      borderBottom: '1px solid var(--border-color)',
+      paddingBottom: '0.5rem',
+      marginBottom: '1.5rem',
+      fontSize: '1.05rem'
+    }}
+  >
+    {['email', 'contact'].map((t) => (
+      <div
+        key={t}
+        onClick={() => setTab(t)}
+        style={{
+          cursor: 'pointer',
+          paddingBottom: '0.25rem',
+          borderBottom:
+            tab === t ? '3px solid var(--accent)' : '3px solid transparent',
+          color: tab === t ? 'var(--text-light)' : 'var(--text-muted)',
+          fontWeight: tab === t ? 'bold' : 'normal'
+        }}
+      >
+        {t === 'email' ? 'Email Groups' : 'Contact Search'}
+      </div>
+    ))}
+  </div>
+)
+
+export default TabSelector

--- a/src/hooks/useRotatingCode.js
+++ b/src/hooks/useRotatingCode.js
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+
+/**
+ * Generate a rotating five digit code that updates on an interval.
+ * @param {number} intervalMs - Duration in milliseconds before the code rotates.
+ * @returns {{currentCode: string, previousCode: string, progressKey: number}}
+ */
+const useRotatingCode = (intervalMs = 5 * 60 * 1000) => {
+  const [currentCode, setCurrentCode] = useState('')
+  const [previousCode, setPreviousCode] = useState('')
+  const [progressKey, setProgressKey] = useState(Date.now())
+  const codeRef = useRef('')
+
+  const generateCode = useCallback(
+    () => Math.floor(10000 + Math.random() * 90000).toString(),
+    []
+  )
+
+  useEffect(() => {
+    const newCode = generateCode()
+    codeRef.current = newCode
+    setCurrentCode(newCode)
+    setProgressKey(Date.now())
+  }, [generateCode])
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPreviousCode(codeRef.current)
+      const newCode = generateCode()
+      codeRef.current = newCode
+      setCurrentCode(newCode)
+      setProgressKey(Date.now())
+    }, intervalMs)
+    return () => clearInterval(interval)
+  }, [generateCode, intervalMs])
+
+  return { currentCode, previousCode, progressKey }
+}
+
+export default useRotatingCode

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './theme.css'
 
+// Mount the React application.
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />

--- a/src/utils/formatPhones.js
+++ b/src/utils/formatPhones.js
@@ -1,0 +1,22 @@
+/**
+ * Normalize phone numbers into "+<country> <local>" format.
+ * Handles multiple numbers separated by common delimiters.
+ * @param {string|number|null|undefined} value
+ * @returns {string}
+ */
+export const formatPhones = (value) => {
+  if (value === undefined || value === null) return ''
+  return String(value)
+    .split(/[\\/;,]+/)
+    .map((num) => num.trim())
+    .filter(Boolean)
+    .map((num) => {
+      const digits = num.replace(/\D/g, '')
+      if (!digits) return ''
+      const country = digits.length > 10 ? digits.slice(0, digits.length - 10) : '1'
+      const local = digits.slice(-10)
+      return `+${country} ${local}`
+    })
+    .filter(Boolean)
+    .join(', ')
+}

--- a/start-app.js
+++ b/start-app.js
@@ -36,7 +36,10 @@ function waitForPort(port, host, timeout = 10000, interval = 500) {
   })
 }
 
-async function start() {
+/**
+ * Launch the Vite dev server and, once ready, start Electron.
+ */
+async function startDev() {
   const vite = spawn('npx', ['vite'], { stdio: 'inherit', shell: true })
 
   try {
@@ -44,7 +47,7 @@ async function start() {
 
     const electron = spawn('npx', ['electron', '.'], {
       stdio: 'inherit',
-      shell: true
+      shell: true,
     })
 
     const shutdown = () => {
@@ -63,5 +66,5 @@ async function start() {
   }
 }
 
-start()
+startDev()
 


### PR DESCRIPTION
## Summary
- centralize code rotation logic with new `useRotatingCode` hook
- document main, preload, and startup modules for clarity
- clarify component responsibilities with JSDoc annotations

## Testing
- `CI=1 npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68965c9a5b2483288a1a503de90ccfd6