### PR TITLE
Make header and search areas sticky

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,53 +110,63 @@ function App() {
         fontFamily: 'DM Sans, sans-serif',
         background: 'var(--bg-primary)',
         color: 'var(--text-light)',
-        minHeight: '100vh',
         padding: '2rem',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
       }}
     >
       <Toaster position="top-right" toastOptions={toastOptions} />
-      <CodeDisplay currentCode={currentCode} previousCode={previousCode} progressKey={progressKey} />
-      {logoAvailable ? (
-        <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
-      ) : (
-        <pre
-          style={{
-            fontFamily: 'monospace',
-            fontSize: '1rem',
-            marginBottom: '1rem',
-            lineHeight: '1.2',
-          }}
-        >{`    _   ______  ______   __    _      __
+
+      {/* Header section remains fixed */}
+      <div style={{ flex: '0 0 auto' }}>
+        <CodeDisplay currentCode={currentCode} previousCode={previousCode} progressKey={progressKey} />
+        {logoAvailable ? (
+          <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
+        ) : (
+          <pre
+            style={{
+              fontFamily: 'monospace',
+              fontSize: '1rem',
+              marginBottom: '1rem',
+              lineHeight: '1.2',
+            }}
+          >{`    _   ______  ______   __    _      __
    / | / / __ \\/ ____/  / /   (_)____/ /_
   /  |/ / / / / /      / /   / / ___/ __/
  / /|  / /_/ / /___   / /___/ (__  ) /_
 /_/ |_|\\____/\\____/  /_____/_/____/\\__/`}</pre>
-      )}
-      <TabSelector tab={tab} setTab={setTab} />
+        )}
+        <TabSelector tab={tab} setTab={setTab} />
 
-      <div
-        className="stack-on-small"
-        style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}
-      >
-        <button onClick={refreshData} className="btn">
-          Refresh Data
-        </button>
-        <span style={{ alignSelf: 'center', fontSize: '0.9rem' }}>
-          Last Refreshed: {lastRefresh}
-        </span>
+        <div
+          className="stack-on-small"
+          style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}
+        >
+          <button onClick={refreshData} className="btn">
+            Refresh Data
+          </button>
+          <span style={{ alignSelf: 'center', fontSize: '0.9rem' }}>
+            Last Refreshed: {lastRefresh}
+          </span>
+        </div>
       </div>
 
-      {tab === 'email' ? (
-        <EmailGroups
-          emailData={emailData}
-          adhocEmails={adhocEmails}
-          selectedGroups={selectedGroups}
-          setSelectedGroups={setSelectedGroups}
-          setAdhocEmails={setAdhocEmails}
-        />
-      ) : (
-        <ContactSearch contactData={contactData} addAdhocEmail={addAdhocEmail} />
-      )}
+      {/* Scrollable content area */}
+      <div style={{ flex: '1 1 auto', overflowY: 'auto' }}>
+        {tab === 'email' ? (
+          <EmailGroups
+            emailData={emailData}
+            adhocEmails={adhocEmails}
+            selectedGroups={selectedGroups}
+            setSelectedGroups={setSelectedGroups}
+            setAdhocEmails={setAdhocEmails}
+          />
+        ) : (
+          <ContactSearch contactData={contactData} addAdhocEmail={addAdhocEmail} />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -20,34 +20,49 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
 
   return (
     <div>
-      <div style={{ marginBottom: '1rem' }}>
-        <button
-          onClick={() => window.nocListAPI?.openFile?.('contacts.xlsx')}
-          className="btn btn-secondary open-contact-btn"
-          style={{ borderRadius: '6px' }}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          background: 'var(--bg-primary)',
+          zIndex: 1,
+          paddingBottom: '1rem',
+        }}
+      >
+        <div style={{ marginBottom: '1rem' }}>
+          <button
+            onClick={() => window.nocListAPI?.openFile?.('contacts.xlsx')}
+            className="btn btn-secondary open-contact-btn"
+            style={{ borderRadius: '6px' }}
+          >
+            Open Contact List Excel
+          </button>
+        </div>
+        <div
+          className="stack-on-small"
+          style={{ alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}
         >
-          Open Contact List Excel
-        </button>
-      </div>
-      <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
-        <div style={{ position: 'relative', flex: '1 1 250px', minWidth: 0, maxWidth: '300px' }}>
-          <input
-            type="text"
-            placeholder="Search contacts..."
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-            className="input"
-            style={{ width: '100%', paddingRight: '2.25rem', borderRadius: '6px' }}
-          />
-          {query && (
-            <button
-              onClick={() => setQuery('')}
-              className="clear-btn"
-              title="Clear search"
-            >
-              ✕
-            </button>
-          )}
+          <div
+            style={{ position: 'relative', flex: '1 1 250px', minWidth: 0, maxWidth: '300px' }}
+          >
+            <input
+              type="text"
+              placeholder="Search contacts..."
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              className="input"
+              style={{ width: '100%', paddingRight: '2.25rem', borderRadius: '6px' }}
+            />
+            {query && (
+              <button
+                onClick={() => setQuery('')}
+                className="clear-btn"
+                title="Clear search"
+              >
+                ✕
+              </button>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -84,34 +84,47 @@ const EmailGroups = ({
 
   return (
     <div>
-      <div style={{ marginBottom: '1.5rem' }}>
-        <button
-          onClick={() => window.nocListAPI?.openFile?.('groups.xlsx')}
-          className="btn btn-secondary"
-        >
-          Open Email Groups Excel
-        </button>
-      </div>
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          background: 'var(--bg-primary)',
+          zIndex: 1,
+          paddingBottom: '1.5rem',
+        }}
+      >
+        <div style={{ marginBottom: '1.5rem' }}>
+          <button
+            onClick={() => window.nocListAPI?.openFile?.('groups.xlsx')}
+            className="btn btn-secondary"
+          >
+            Open Email Groups Excel
+          </button>
+        </div>
 
-      <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1.5rem', gap: '0.5rem' }}>
-        <div style={{ position: 'relative', flex: '1 1 250px', maxWidth: '300px' }}>
-          <input
-            type="text"
-            placeholder="Search groups..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            className="input"
-            style={{ width: '100%', paddingRight: '1.75rem' }}
-          />
-          {search && (
-            <button
-              onClick={() => setSearch('')}
-              className="clear-btn"
-              title="Clear search"
-            >
-              ✕
-            </button>
-          )}
+        <div
+          className="stack-on-small"
+          style={{ alignItems: 'center', marginBottom: '1.5rem', gap: '0.5rem' }}
+        >
+          <div style={{ position: 'relative', flex: '1 1 250px', maxWidth: '300px' }}>
+            <input
+              type="text"
+              placeholder="Search groups..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="input"
+              style={{ width: '100%', paddingRight: '1.75rem' }}
+            />
+            {search && (
+              <button
+                onClick={() => setSearch('')}
+                className="clear-btn"
+                title="Clear search"
+              >
+                ✕
+              </button>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Restructure App layout with fixed header and scrollable content area
- Keep contact and group search bars pinned using CSS `position: sticky`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68966bcfb69c832883913da8e963aacd