### PR TITLE
Keep header and code static during scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -119,25 +119,43 @@ function App() {
     >
       <Toaster position="top-right" toastOptions={toastOptions} />
 
-      {/* Header section remains fixed */}
-      <div style={{ flex: '0 0 auto' }}>
-        <CodeDisplay currentCode={currentCode} previousCode={previousCode} progressKey={progressKey} />
-        {logoAvailable ? (
-          <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
-        ) : (
-          <pre
-            style={{
-              fontFamily: 'monospace',
-              fontSize: '1rem',
-              marginBottom: '1rem',
-              lineHeight: '1.2',
-            }}
-          >{`    _   ______  ______   __    _      __
+      {/* Header section stays fixed at the top */}
+      <header
+        style={{
+          flex: '0 0 auto',
+          position: 'sticky',
+          top: 0,
+          zIndex: 10,
+          background: 'var(--bg-primary)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          {logoAvailable ? (
+            <img
+              src="logo.png"
+              alt="NOC List Logo"
+              style={{ width: '200px', marginBottom: '1rem' }}
+            />
+          ) : (
+            <pre
+              style={{
+                fontFamily: 'monospace',
+                fontSize: '1rem',
+                marginBottom: '1rem',
+                lineHeight: '1.2',
+              }}
+            >{`    _   ______  ______   __    _      __
    / | / / __ \\/ ____/  / /   (_)____/ /_
   /  |/ / / / / /      / /   / / ___/ __/
  / /|  / /_/ / /___   / /___/ (__  ) /_
 /_/ |_|\\____/\\____/  /_____/_/____/\\__/`}</pre>
-        )}
+          )}
+          <CodeDisplay
+            currentCode={currentCode}
+            previousCode={previousCode}
+            progressKey={progressKey}
+          />
+        </div>
         <TabSelector tab={tab} setTab={setTab} />
 
         <div
@@ -151,7 +169,7 @@ function App() {
             Last Refreshed: {lastRefresh}
           </span>
         </div>
-      </div>
+      </header>
 
       {/* Scrollable content area */}
       <div style={{ flex: '1 1 auto', overflowY: 'auto' }}>

--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -11,9 +11,7 @@ import React from 'react'
 const CodeDisplay = ({ currentCode, previousCode, progressKey }) => (
   <div
     style={{
-      position: 'fixed',
-      top: '1rem',
-      right: '1rem',
+      marginLeft: 'auto',
       background: 'var(--bg-secondary)',
       border: '1px solid var(--border-color)',
       borderRadius: '4px',


### PR DESCRIPTION
## Summary
- Keep header section at the top using a sticky header container
- Remove fixed positioning from CodeDisplay so code stays within the header on scroll

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_689a8e350f1c83288a46fdb7f4ab58da