### PR TITLE
feat: add cohesive header with clock and weather

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import EmailGroups from './components/EmailGroups'
 import ContactSearch from './components/ContactSearch'
+import Header from './components/Header'
 import { Toaster, toast } from 'react-hot-toast'
 
 function App() {
@@ -105,31 +106,14 @@ function App() {
   };
 
   return (
-    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}>
+    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '0 2rem 2rem' }}>
       <Toaster position="top-right" toastOptions={toastOptions} />
-      <div style={{ position: 'fixed', top: '1rem', right: '1rem', background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '0.5rem 1rem', textAlign: 'center', fontSize: '0.9rem' }}>
-        <div style={{ fontSize: '1.6rem', fontWeight: 'bold' }}>Code: {currentCode}</div>
-        <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Prev: {previousCode || 'N/A'}</div>
-        <div className="progress-container">
-          <div key={progressKey} className="progress-bar" />
-        </div>
-      </div>
-      {logoAvailable ? (
-        <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
-      ) : (
-        <pre style={{
-          fontFamily: 'monospace',
-          fontSize: '1rem',
-          marginBottom: '1rem',
-          lineHeight: '1.2',
-        }}>
-          {`    _   ______  ______   __    _      __
-   / | / / __ \/ ____/  / /   (_)____/ /_
-  /  |/ / / / / /      / /   / / ___/ __/
- / /|  / /_/ / /___   / /___/ (__  ) /_
-/_/ |_|\____/\____/  /_____/_/____/\__/`}
-        </pre>
-      )}
+      <Header
+        currentCode={currentCode}
+        previousCode={previousCode}
+        progressKey={progressKey}
+        logoAvailable={logoAvailable}
+      />
       <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
       <div
         className="stack-on-small"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react'
+
+function Header({ currentCode, previousCode, progressKey, logoAvailable }) {
+  const [time, setTime] = useState(new Date())
+  const [weather, setWeather] = useState(null)
+
+  useEffect(() => {
+    const interval = setInterval(() => setTime(new Date()), 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    if (typeof fetch === 'undefined') return
+    fetch('https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.0060&current_weather=true')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.current_weather) setWeather(data.current_weather)
+      })
+      .catch(() => {})
+  }, [])
+
+  return (
+    <header className="header">
+      {logoAvailable ? (
+        <img src="logo.png" alt="NOC List Logo" className="header-logo" />
+      ) : (
+        <pre className="header-logo-ascii">{`    _   ______  ______   __    _      __\n / | / / __ \\/ ____/  / /   (_)____/ /_\n/  |/ / / / / /      / /   / / ___/ __/\n/ /|  / /_/ / /___   / /___/ (__  ) /_\n/_/ |_|\\____/\\____/  /_____/_/____/\\__/`}</pre>
+      )}
+      <div className="header-info">
+        <div className="code-box">
+          <div className="code">Code: {currentCode}</div>
+          <div className="prev-code">Prev: {previousCode || 'N/A'}</div>
+          <div className="progress-container">
+            <div key={progressKey} className="progress-bar" />
+          </div>
+        </div>
+        <div className="clock-weather">
+          <div>{time.toLocaleTimeString()}</div>
+          {weather && <div className="weather">{Math.round(weather.temperature)}°C</div>}
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export default Header

--- a/src/theme.css
+++ b/src/theme.css
@@ -208,11 +208,63 @@ body::-webkit-scrollbar-thumb {
   animation: code-progress 300s linear forwards;
 }
 
-@keyframes code-progress {
-  from {
-    width: 0%;
+  @keyframes code-progress {
+    from {
+      width: 0%;
+    }
+    to {
+      width: 100%;
+    }
   }
-  to {
-    width: 100%;
+
+  /* Header styling */
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    padding: 1rem 2rem;
   }
-}
+
+  .header-logo {
+    height: 60px;
+  }
+
+  .header-logo-ascii {
+    font-family: monospace;
+    font-size: 1rem;
+    line-height: 1.2;
+    white-space: pre;
+  }
+
+  .header-info {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    color: var(--text-light);
+  }
+
+  .code-box {
+    text-align: center;
+  }
+
+  .code-box .code {
+    font-size: 1.6rem;
+    font-weight: bold;
+  }
+
+  .code-box .prev-code {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  .clock-weather {
+    text-align: right;
+    font-size: 0.9rem;
+  }
+
+  .clock-weather .weather {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+  }


### PR DESCRIPTION
## Summary
- add Header component combining logo, code display, clock, and weather
- update App to use new Header and remove duplicate elements
- style header to match existing theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bdbb171bc8328b7ddd609fb4ad9ea