### PR TITLE
Remove seconds from clock and slim scrollbars

### DIFF
--- a/src/components/WeatherClock.jsx
+++ b/src/components/WeatherClock.jsx
@@ -62,7 +62,9 @@ const WeatherClock = () => {
 
   return (
     <div style={{ textAlign: 'center', lineHeight: '1.2' }}>
-      <div style={{ fontSize: '1.4rem', fontWeight: 'bold' }}>{now.toLocaleTimeString()}</div>
+      <div style={{ fontSize: '1.4rem', fontWeight: 'bold' }}>
+        {now.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+      </div>
       {weather && (
         <div style={{ fontSize: '0.9rem' }}>
           Bowling Green: {Math.round(weather.temp)}°F {description}

--- a/src/theme.css
+++ b/src/theme.css
@@ -170,22 +170,24 @@ a[href^="mailto:"]:hover {
 }
 
 /* Minimal themed scrollbars */
-body {
+* {
   scrollbar-width: thin; /* Firefox */
-  scrollbar-color: var(--accent) var(--bg-primary);
+  scrollbar-color: var(--accent) transparent;
 }
 
-body::-webkit-scrollbar {
-  width: 6px;
+*::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
 }
 
-body::-webkit-scrollbar-track {
-  background: var(--bg-primary);
+*::-webkit-scrollbar-track {
+  background: transparent;
 }
 
-body::-webkit-scrollbar-thumb {
+*::-webkit-scrollbar-thumb {
   background-color: var(--accent);
   border-radius: 4px;
+  opacity: 0.5;
 }
 
 /* Progress bar for code timer */


### PR DESCRIPTION
## Summary
- Drop seconds from clock display for a cleaner time readout
- Apply minimal, translucent scrollbars globally for improved aesthetics

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689cf1a68c2c8328a6f0a8ceae4f1101