### PR TITLE
Refactor Excel loading to async IPC

### DIFF
--- a/main.js
+++ b/main.js
@@ -133,10 +133,7 @@ if (process.env.NODE_ENV !== 'test') {
     }
   })
 
-  ipcMain.on('load-excel-data', (event) => {
-    loadExcelFiles()
-    event.returnValue = cachedData
-  })
+  ipcMain.handle('load-excel-data', async () => cachedData)
 
   ipcMain.on('open-excel-file', (event, filename) => {
     const filePath = path.join(basePath, filename)

--- a/preload.js
+++ b/preload.js
@@ -5,10 +5,10 @@ const { contextBridge, ipcRenderer } = require('electron')
  */
 contextBridge.exposeInMainWorld('nocListAPI', {
   /**
-   * Load Excel data synchronously from the main process.
-   * @returns {{emailData: any[], contactData: any[]}}
+   * Load Excel data asynchronously from the main process.
+   * @returns {Promise<{emailData: any[], contactData: any[]}>}
    */
-  loadExcelData: () => ipcRenderer.sendSync('load-excel-data'),
+  loadExcelData: () => ipcRenderer.invoke('load-excel-data'),
 
   /**
    * Ask the main process to open an Excel file.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,8 +20,8 @@ function App() {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
   /** Load group and contact data from the preloaded Excel files. */
-  const loadData = useCallback(() => {
-    const { emailData, contactData } = window.nocListAPI.loadExcelData()
+  const loadData = useCallback(async () => {
+    const { emailData, contactData } = await window.nocListAPI.loadExcelData()
     setEmailData(emailData)
     setContactData(contactData)
     setLastRefresh(new Date().toLocaleString())
@@ -63,8 +63,8 @@ function App() {
   }, [])
 
   /** Manually refresh Excel data and clear any ad-hoc emails. */
-  const refreshData = useCallback(() => {
-    loadData()
+  const refreshData = useCallback(async () => {
+    await loadData()
     setAdhocEmails([])
     toast.success('Data refreshed')
   }, [loadData])

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -9,7 +9,7 @@ describe('App', () => {
       Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
     )
     window.nocListAPI = {
-      loadExcelData: () => ({ emailData: [], contactData: [] }),
+      loadExcelData: async () => ({ emailData: [], contactData: [] }),
       onExcelDataUpdate: () => () => {},
       onExcelWatchError: () => () => {},
     }
@@ -24,7 +24,7 @@ describe('App', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
     )
     window.nocListAPI = {
-      loadExcelData: () => ({ emailData: [], contactData: [] }),
+      loadExcelData: async () => ({ emailData: [], contactData: [] }),
       onExcelDataUpdate: () => () => {},
       onExcelWatchError: () => () => {},
     }
@@ -38,7 +38,7 @@ describe('Excel listener cleanup', () => {
     const cleanup = vi.fn()
     const onExcelDataUpdate = vi.fn(() => cleanup)
     window.nocListAPI = {
-      loadExcelData: () => ({ emailData: [], contactData: [] }),
+      loadExcelData: async () => ({ emailData: [], contactData: [] }),
       onExcelDataUpdate,
       onExcelWatchError: () => () => {},
     }


### PR DESCRIPTION
## Summary
- Replace synchronous Excel data request with `ipcRenderer.invoke`
- Serve cached data via `ipcMain.handle('load-excel-data')`
- Await asynchronous data load in React component and refresh logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d019c16c88328839133f783c6d1f2