### PR TITLE
Index contacts and groups for faster searching

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -9,14 +9,20 @@ import { formatPhones } from '../utils/formatPhones'
  */
 const ContactSearch = ({ contactData, addAdhocEmail }) => {
   const [query, setQuery] = useState('')
+
+  const indexedContacts = useMemo(
+    () =>
+      contactData.map((c) => ({
+        ...c,
+        _search: Object.values(c).join(' ').toLowerCase(),
+      })),
+    [contactData]
+  )
+
   const filtered = useMemo(() => {
     const q = query.toLowerCase()
-    return contactData.filter((c) =>
-      Object.values(c).some((val) =>
-        String(val).toLowerCase().includes(q)
-      )
-    )
-  }, [query, contactData])
+    return indexedContacts.filter((c) => c._search.includes(q))
+  }, [query, indexedContacts])
 
   return (
     <div>

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -25,13 +25,14 @@ const EmailGroups = ({
     const [headers, ...rows] = emailData
     return headers.map((name, i) => ({
       name,
-      emails: rows.map(row => row[i]).filter(Boolean)
+      emails: rows.map(row => row[i]).filter(Boolean),
+      _search: name.toLowerCase(),
     }))
   }, [emailData])
 
   const filteredGroups = useMemo(() => {
     const term = search.toLowerCase()
-    return groups.filter((group) => group.name.toLowerCase().includes(term))
+    return groups.filter((group) => group._search.includes(term))
   }, [groups, search])
 
   const groupMap = useMemo(


### PR DESCRIPTION
## Summary
- Precompute lowercase search strings for contacts and email groups using `useMemo`
- Filter lists using cached `_search` fields to avoid repeated string conversions

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689d019e76f88328ac784a208d93a6d1