### PR TITLE
Add abortable weather fetch with retry

### DIFF
--- a/src/components/WeatherClock.test.jsx
+++ b/src/components/WeatherClock.test.jsx
@@ -5,11 +5,19 @@ import WeatherClock from './WeatherClock'
 
 describe('WeatherClock', () => {
   it('shows fallback message on fetch failure', async () => {
+    vi.useFakeTimers()
+    const originalFetch = global.fetch
     global.fetch = vi.fn(() => Promise.reject(new Error('fail')))
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     render(<WeatherClock />)
-    expect(await screen.findByText(/weather unavailable/i)).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+    expect(screen.getByText(/weather unavailable/i)).toBeInTheDocument()
     expect(errorSpy).toHaveBeenCalled()
     errorSpy.mockRestore()
+    vi.useRealTimers()
+    global.fetch = originalFetch
   })
 })


### PR DESCRIPTION
## Summary
- use AbortController in `WeatherClock` and abort on unmount
- retry failed weather requests once after 5s before showing error
- adjust WeatherClock test to advance fake timers for retry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d01a16b788328b4838b388c6c0333