### PR TITLE
Refactor inline styles into reusable CSS classes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,15 +143,12 @@ function App() {
           background: 'var(--bg-primary)',
         }}
       >
-        <div
-          className="stack-on-small"
-          style={{ alignItems: 'center', gap: '1rem', marginBottom: '1rem' }}
-        >
-          {logoAvailable ? (
-            <img
-              src="logo.png"
-              alt="NOC List Logo"
-              style={{ width: '200px' }}
+          <div className="stack-on-small align-center gap-1 mb-1">
+            {logoAvailable ? (
+              <img
+                src="logo.png"
+                alt="NOC List Logo"
+                style={{ width: '200px' }}
             />
           ) : (
             <pre
@@ -192,17 +189,14 @@ function App() {
         </div>
         <TabSelector tab={tab} setTab={setTab} />
 
-        <div
-          className="stack-on-small"
-          style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}
-        >
-          <button onClick={refreshData} className="btn">
-            Refresh Data
-          </button>
-          <span style={{ alignSelf: 'center', fontSize: '0.9rem' }}>
-            Last Refreshed: {lastRefresh}
-          </span>
-        </div>
+          <div className="stack-on-small gap-1 mb-1">
+            <button onClick={refreshData} className="btn">
+              Refresh Data
+            </button>
+            <span className="small-text self-center">
+              Last Refreshed: {lastRefresh}
+            </span>
+          </div>
       </header>
 
       {/* Scrollable content area */}

--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -10,14 +10,14 @@ import React from 'react'
  * @param {number} props.intervalMs - Duration of code validity in ms.
  */
 const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => (
-  <div style={{ textAlign: 'center' }}>
-    <div style={{ fontSize: '1.4rem', fontWeight: 'bold' }}>
-      Code: {currentCode}
-    </div>
-    <div style={{ fontSize: '0.9rem', color: 'var(--text-muted)' }}>
-      Prev: {previousCode || 'N/A'}
-    </div>
-    <div className="progress-container">
+    <div className="text-center">
+      <div className="large-bold">
+        Code: {currentCode}
+      </div>
+      <div className="small-muted">
+        Prev: {previousCode || 'N/A'}
+      </div>
+      <div className="progress-container">
       <div
         key={progressKey}
         className="progress-bar"

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -26,38 +26,24 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
 
   return (
     <div>
-      <div
-        style={{
-          position: 'sticky',
-          top: 0,
-          background: 'var(--bg-primary)',
-          zIndex: 1,
-          paddingBottom: '1rem',
-        }}
-      >
-        <div style={{ marginBottom: '1rem' }}>
+      <div className="sticky-header">
+        <div className="mb-1">
           <button
             onClick={() => window.nocListAPI?.openFile?.('contacts.xlsx')}
-            className="btn btn-secondary open-contact-btn"
-            style={{ borderRadius: '6px' }}
+            className="btn btn-secondary open-contact-btn rounded-6"
           >
             Open Contact List Excel
           </button>
         </div>
-        <div
-          className="stack-on-small"
-          style={{ alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}
-        >
-          <div
-            style={{ position: 'relative', flex: '1 1 250px', minWidth: 0, maxWidth: '300px' }}
-          >
+        <div className="stack-on-small align-center gap-0-5 mb-1">
+          <div className="input-wrapper">
             <input
               type="text"
               placeholder="Search contacts..."
               value={query}
               onChange={e => setQuery(e.target.value)}
-              className="input"
-              style={{ width: '100%', paddingRight: '2.25rem', borderRadius: '6px' }}
+              className="input rounded-6 search-input"
+              style={{ '--clear-btn-space': '2.25rem' }}
             />
             {query && (
               <button
@@ -83,41 +69,35 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
         >
           {filtered.map((contact) => (
             <div key={contact.Email} className="contact-card">
-              <strong>{contact.Name}</strong>
-              <p style={{ margin: '0.5rem 0 0 0' }}>
-                <span className="label">Title:</span> {contact.Title}
-              </p>
-              <p style={{ margin: 0 }}>
-                <span className="label">Email:</span>{' '}
-                <a
-                  href={`mailto:${contact.Email}`}
-                  style={{ whiteSpace: 'nowrap' }}
-                >
-                  {contact.Email}
-                </a>
-              </p>
-              <p style={{ margin: 0 }}>
-                <span className="label">Phone:</span> {formatPhones(contact.Phone)}
-              </p>
-              <button
-                onClick={() => addAdhocEmail(contact.Email)}
-                className="btn"
-                style={{
-                  marginTop: '0.5rem',
-                  padding: '0.25rem 0.75rem',
-                  borderRadius: '6px',
-                  fontSize: '1rem'
-                }}
+            <strong>{contact.Name}</strong>
+            <p className="m-0 mt-0-5">
+              <span className="label">Title:</span> {contact.Title}
+            </p>
+            <p className="m-0">
+              <span className="label">Email:</span>{' '}
+              <a
+                href={`mailto:${contact.Email}`}
+                style={{ whiteSpace: 'nowrap' }}
               >
-                Add to Email List
-              </button>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <p style={{ color: 'var(--text-muted)' }}>No matching contacts.</p>
-      )}
-    </div>
+                {contact.Email}
+              </a>
+            </p>
+            <p className="m-0">
+              <span className="label">Phone:</span> {formatPhones(contact.Phone)}
+            </p>
+            <button
+              onClick={() => addAdhocEmail(contact.Email)}
+              className="btn btn-small rounded-6 mt-0-5"
+            >
+              Add to Email List
+            </button>
+          </div>
+        ))}
+      </div>
+    ) : (
+      <p className="text-muted">No matching contacts.</p>
+    )}
+  </div>
   )
 }
 

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -85,41 +85,29 @@ const EmailGroups = ({
 
   return (
     <div>
-      <div
-        style={{
-          position: 'sticky',
-          top: 0,
-          background: 'var(--bg-primary)',
-          zIndex: 1,
-          paddingBottom: '1.5rem',
-        }}
-      >
-        <div style={{ marginBottom: '1.5rem' }}>
-          <button
-            onClick={() => window.nocListAPI?.openFile?.('groups.xlsx')}
-            className="btn btn-secondary"
-          >
-            Open Email Groups Excel
-          </button>
-        </div>
+        <div className="sticky-header" style={{ '--sticky-padding': '1.5rem' }}>
+          <div className="mb-1-5">
+            <button
+              onClick={() => window.nocListAPI?.openFile?.('groups.xlsx')}
+              className="btn btn-secondary"
+            >
+              Open Email Groups Excel
+            </button>
+          </div>
 
-        <div
-          className="stack-on-small"
-          style={{ alignItems: 'center', marginBottom: '1.5rem', gap: '0.5rem' }}
-        >
-          <div style={{ position: 'relative', flex: '1 1 250px', maxWidth: '300px' }}>
-            <input
-              type="text"
-              placeholder="Search groups..."
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              className="input"
-              style={{ width: '100%', paddingRight: '1.75rem' }}
-            />
-            {search && (
-              <button
-                onClick={() => setSearch('')}
-                className="clear-btn"
+          <div className="stack-on-small align-center gap-0-5 mb-1-5">
+            <div className="input-wrapper">
+              <input
+                type="text"
+                placeholder="Search groups..."
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                className="input search-input"
+              />
+              {search && (
+                <button
+                  onClick={() => setSearch('')}
+                  className="clear-btn"
                 title="Clear search"
               >
                 ✕
@@ -129,24 +117,18 @@ const EmailGroups = ({
         </div>
       </div>
 
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1.5rem' }}>
-        {filteredGroups.map(group => (
-          <button
-            key={group.name}
-            onClick={() => toggleSelect(group.name)}
-            className="btn fade-in"
-            style={{
-              background: selectedGroups.includes(group.name)
-                ? 'var(--button-active)'
-                : 'var(--button-bg)',
-              color: 'var(--text-light)'
-            }}
-          >
-            {group.name}
-            <span style={{ marginLeft: '0.25rem', fontSize: '0.8rem', color: 'var(--text-light)' }}>
-              ({group.emails.length})
-            </span>
-          </button>
+        <div className="flex-wrap gap-0-5 mb-1-5">
+          {filteredGroups.map(group => (
+            <button
+              key={group.name}
+              onClick={() => toggleSelect(group.name)}
+              className={`btn fade-in ${selectedGroups.includes(group.name) ? 'active' : ''}`}
+            >
+              {group.name}
+              <span style={{ marginLeft: '0.25rem', fontSize: '0.8rem', color: 'var(--text-light)' }}>
+                ({group.emails.length})
+              </span>
+            </button>
         ))}
         {(selectedGroups.length > 0 || adhocEmails.length > 0) && (
           <button onClick={clearAll} className="btn btn-secondary fade-in">
@@ -157,24 +139,24 @@ const EmailGroups = ({
 
       {mergedEmails.length > 0 && (
         <>
-          <div style={{ marginBottom: '0.5rem', display: 'flex', gap: '0.5rem' }}>
-            <button onClick={copyToClipboard} className="btn fade-in">
-              Copy Email List
-            </button>
-            <button onClick={launchTeams} className="btn btn-secondary fade-in">
-              Start Teams Meeting
-            </button>
-            {copied && <span style={{ color: 'lightgreen', alignSelf: 'center' }}>Copied</span>}
-          </div>
-          <div style={{ background: 'var(--bg-secondary)', padding: '1rem', borderRadius: '4px', color: 'var(--text-light)' }}>
-            <strong>Merged Emails:</strong>
-            <div style={{ wordBreak: 'break-word', marginTop: '0.5rem' }}>
-              {mergedEmails.join(', ')}
+            <div className="flex gap-0-5 mb-0-5">
+              <button onClick={copyToClipboard} className="btn fade-in">
+                Copy Email List
+              </button>
+              <button onClick={launchTeams} className="btn btn-secondary fade-in">
+                Start Teams Meeting
+              </button>
+              {copied && <span className="self-center" style={{ color: 'lightgreen' }}>Copied</span>}
             </div>
-          </div>
-        </>
-      )}
-    </div>
+            <div style={{ background: 'var(--bg-secondary)', padding: '1rem', borderRadius: '4px', color: 'var(--text-light)' }}>
+              <strong>Merged Emails:</strong>
+              <div className="break-word mt-0-5">
+                {mergedEmails.join(', ')}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
   )
 }
 

--- a/src/components/TabSelector.jsx
+++ b/src/components/TabSelector.jsx
@@ -6,43 +6,25 @@ import React from 'react'
  * @param {'email'|'contact'} props.tab - Currently active tab.
  * @param {(tab: string) => void} props.setTab - Update active tab.
  */
-const TabSelector = ({ tab, setTab }) => (
-  <div
-    className="stack-on-small"
-    style={{
-      gap: '2rem',
-      borderBottom: '1px solid var(--border-color)',
-      paddingBottom: '0.5rem',
-      marginBottom: '1.5rem',
-      fontSize: '1.05rem'
-    }}
-  >
-    {['email', 'contact'].map((t) => (
-      <button
-        key={t}
-        type="button"
-        onClick={() => setTab(t)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            setTab(t)
-          }
-        }}
-        style={{
-          cursor: 'pointer',
-          paddingBottom: '0.25rem',
-          border: 'none',
-          background: 'transparent',
-          borderBottom:
-            tab === t ? '3px solid var(--accent)' : '3px solid transparent',
-          color: tab === t ? 'var(--text-light)' : 'var(--text-muted)',
-          fontWeight: tab === t ? 'bold' : 'normal'
-        }}
-      >
-        {t === 'email' ? 'Email Groups' : 'Contact Search'}
-      </button>
-    ))}
-  </div>
+  const TabSelector = ({ tab, setTab }) => (
+    <div className="stack-on-small tab-selector">
+      {['email', 'contact'].map((t) => (
+        <button
+          key={t}
+          type="button"
+          onClick={() => setTab(t)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              setTab(t)
+            }
+          }}
+          className={`tab-button ${tab === t ? 'active' : ''}`}
+        >
+          {t === 'email' ? 'Email Groups' : 'Contact Search'}
+        </button>
+      ))}
+    </div>
 )
 
 export default TabSelector

--- a/src/components/WeatherClock.jsx
+++ b/src/components/WeatherClock.jsx
@@ -87,22 +87,22 @@ const WeatherClock = () => {
 
   const description = useMemo(() => weatherCodeMap[weather?.code] || '', [weather])
 
-  return (
-    <div style={{ textAlign: 'center', lineHeight: '1.2' }}>
-      <div style={{ fontSize: '1.4rem', fontWeight: 'bold' }}>
-        {now.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+    return (
+      <div className="text-center line-tight">
+        <div className="large-bold">
+          {now.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+        </div>
+        {weather && (
+          <div className="small-text">
+            Bowling Green: {Math.round(weather.temp)}°F {description}
+          </div>
+        )}
+        {error && (
+          <div className="small-muted">
+            Weather unavailable
+          </div>
+        )}
       </div>
-      {weather && (
-        <div style={{ fontSize: '0.9rem' }}>
-          Bowling Green: {Math.round(weather.temp)}°F {description}
-        </div>
-      )}
-      {error && (
-        <div style={{ fontSize: '0.9rem', color: 'var(--text-muted)' }}>
-          Weather unavailable
-        </div>
-      )}
-    </div>
   )
 }
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -100,6 +100,69 @@ body {
   transform: translateY(-50%) scale(1.2);
 }
 
+/* Utility classes */
+.text-center { text-align: center; }
+.line-tight { line-height: 1.2; }
+.large-bold { font-size: 1.4rem; font-weight: bold; }
+.small-text { font-size: 0.9rem; }
+.small-muted { font-size: 0.9rem; color: var(--text-muted); }
+.text-muted { color: var(--text-muted); }
+.self-center { align-self: center; }
+.flex { display: flex; }
+.flex-wrap { display: flex; flex-wrap: wrap; }
+.align-center { align-items: center; }
+.gap-0-5 { gap: 0.5rem; }
+.gap-1 { gap: 1rem; }
+.mb-0 { margin-bottom: 0; }
+.mb-0-5 { margin-bottom: 0.5rem; }
+.mb-1 { margin-bottom: 1rem; }
+.mb-1-5 { margin-bottom: 1.5rem; }
+.mt-0-5 { margin-top: 0.5rem; }
+.m-0 { margin: 0; }
+.rounded-6 { border-radius: 6px; }
+.sticky-header {
+  position: sticky;
+  top: 0;
+  background: var(--bg-primary);
+  z-index: 1;
+  padding-bottom: var(--sticky-padding, 1rem);
+}
+.input-wrapper {
+  position: relative;
+  flex: 1 1 250px;
+  max-width: 300px;
+  min-width: 0;
+}
+.search-input {
+  width: 100%;
+  padding-right: var(--clear-btn-space, 1.75rem);
+}
+.tab-selector {
+  gap: 2rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 1.05rem;
+}
+.tab-button {
+  cursor: pointer;
+  padding-bottom: 0.25rem;
+  border: none;
+  background: transparent;
+  border-bottom: 3px solid transparent;
+  color: var(--text-muted);
+}
+.tab-button.active {
+  border-bottom: 3px solid var(--accent);
+  color: var(--text-light);
+  font-weight: bold;
+}
+.btn-small {
+  padding: 0.25rem 0.75rem;
+  font-size: 1rem;
+}
+.break-word { word-break: break-word; }
+
 /* Contact cards */
 .contact-card {
   background: var(--bg-secondary);


### PR DESCRIPTION
## Summary
- centralize common layout and typography styles in `theme.css`
- switch components to class-based styling with CSS variables for dynamic values
- clean up tab selector with state-driven classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d01a1ecc4832898429daf76de1229