### PR TITLE
feat: incrementally reload Excel data

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,24 +21,34 @@ const getExcelPaths = () => ({
 
 /**
  * Read Excel sheets and cache the parsed data for quick access.
+ *
+ * @param {string} [changedFilePath] - optional full path to a specific Excel
+ *   file that has changed. If provided, only that file is re-read and merged
+ *   into the cached data.
  */
-function loadExcelFiles() {
+function loadExcelFiles(changedFilePath) {
+  const { groupsPath, contactsPath } = getExcelPaths()
+
   try {
-    const { groupsPath, contactsPath } = getExcelPaths()
-
-    const groupWorkbook = xlsx.readFile(groupsPath)
-    const contactWorkbook = xlsx.readFile(contactsPath)
-
-    const groupSheet = groupWorkbook.Sheets[groupWorkbook.SheetNames[0]]
-    const contactSheet = contactWorkbook.Sheets[contactWorkbook.SheetNames[0]]
-
-    cachedData = {
-      emailData: xlsx.utils.sheet_to_json(groupSheet, { header: 1 }),
-      contactData: xlsx.utils.sheet_to_json(contactSheet),
+    if (!changedFilePath || changedFilePath === groupsPath) {
+      const groupWorkbook = xlsx.readFile(groupsPath)
+      const groupSheet = groupWorkbook.Sheets[groupWorkbook.SheetNames[0]]
+      cachedData.emailData = xlsx.utils.sheet_to_json(groupSheet, { header: 1 })
     }
   } catch (err) {
-    console.error('Error reading Excel files:', err)
-    cachedData = { emailData: [], contactData: [] }
+    console.error('Error reading groups file:', err)
+    cachedData.emailData = []
+  }
+
+  try {
+    if (!changedFilePath || changedFilePath === contactsPath) {
+      const contactWorkbook = xlsx.readFile(contactsPath)
+      const contactSheet = contactWorkbook.Sheets[contactWorkbook.SheetNames[0]]
+      cachedData.contactData = xlsx.utils.sheet_to_json(contactSheet)
+    }
+  } catch (err) {
+    console.error('Error reading contacts file:', err)
+    cachedData.contactData = []
   }
 }
 
@@ -62,7 +72,7 @@ function watchExcelFiles() {
 
   const onChange = (filePath) => {
     console.log(`File changed: ${filePath}`)
-    loadExcelFiles()
+    loadExcelFiles(filePath)
     sendExcelUpdate()
   }
 
@@ -154,6 +164,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 module.exports = {
   watchExcelFiles,
+  loadExcelFiles,
   __setWin: (w) => (win = w),
   __setCachedData: (data) => (cachedData = data),
   getCachedData: () => cachedData,

--- a/main.test.js
+++ b/main.test.js
@@ -1,0 +1,67 @@
+/** @vitest-environment node */
+import fs from 'fs'
+import path from 'path'
+import xlsx from 'xlsx'
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const electronPath = require.resolve('electron')
+require.cache[electronPath] = {
+  exports: {
+    app: { isPackaged: false },
+    BrowserWindow: vi.fn(),
+    ipcMain: { on: vi.fn(), handle: vi.fn() },
+    shell: {},
+  },
+}
+
+const { loadExcelFiles, getCachedData, __setCachedData } = require('./main.js')
+
+const groupsPath = path.join(__dirname, 'groups.xlsx')
+const contactsPath = path.join(__dirname, 'contacts.xlsx')
+const originalGroups = fs.readFileSync(groupsPath)
+const originalContacts = fs.readFileSync(contactsPath)
+
+afterAll(() => {
+  fs.writeFileSync(groupsPath, originalGroups)
+  fs.writeFileSync(contactsPath, originalContacts)
+})
+
+describe('incremental Excel loading', () => {
+  beforeEach(() => {
+    // Seed initial data for both files
+    const groupWB = xlsx.utils.book_new()
+    const groupSheet = xlsx.utils.aoa_to_sheet([['email'], ['initial@example.com']])
+    xlsx.utils.book_append_sheet(groupWB, groupSheet, 'Sheet1')
+    xlsx.writeFile(groupWB, groupsPath)
+
+    const contactWB = xlsx.utils.book_new()
+    const contactSheet = xlsx.utils.json_to_sheet([{ Name: 'Alice', Email: 'alice@example.com' }])
+    xlsx.utils.book_append_sheet(contactWB, contactSheet, 'Sheet1')
+    xlsx.writeFile(contactWB, contactsPath)
+
+    __setCachedData({ emailData: [], contactData: [] })
+    loadExcelFiles()
+  })
+
+  it('updates only the modified workbook', () => {
+    const initial = getCachedData()
+    expect(initial.contactData).toEqual([{ Name: 'Alice', Email: 'alice@example.com' }])
+    expect(initial.emailData[1][0]).toBe('initial@example.com')
+
+    // Modify contacts file only
+    const newContactWB = xlsx.utils.book_new()
+    const newContactSheet = xlsx.utils.json_to_sheet([{ Name: 'Bob', Email: 'bob@example.com' }])
+    xlsx.utils.book_append_sheet(newContactWB, newContactSheet, 'Sheet1')
+    xlsx.writeFile(newContactWB, contactsPath)
+
+    loadExcelFiles(contactsPath)
+
+    const updated = getCachedData()
+    // Email data remains the same
+    expect(updated.emailData).toEqual(initial.emailData)
+    // Contact data reflects new file
+    expect(updated.contactData).toEqual([{ Name: 'Bob', Email: 'bob@example.com' }])
+  })
+})


### PR DESCRIPTION
## Summary
- let `loadExcelFiles` optionally target a single workbook and merge results into cache
- re-read only the changed Excel file when watcher `onChange` fires
- add regression test covering cached data updates when one file changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d01a3b9108328a7a51e33caeeb29f