### PR TITLE
test: add rotating code hook test

### DIFF
--- a/src/hooks/useRotatingCode.test.js
+++ b/src/hooks/useRotatingCode.test.js
@@ -1,0 +1,32 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import useRotatingCode from './useRotatingCode'
+
+describe('useRotatingCode', () => {
+  it('rotates code and clears interval on unmount', () => {
+    vi.useFakeTimers()
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval')
+    const randomMock = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.1)
+      .mockReturnValue(0.2)
+
+    const { result, unmount } = renderHook(() => useRotatingCode(1000))
+
+    expect(result.current.currentCode).toBe('19000')
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(result.current.previousCode).toBe('19000')
+    expect(result.current.currentCode).toBe('28000')
+
+    unmount()
+    expect(clearIntervalSpy).toHaveBeenCalled()
+
+    randomMock.mockRestore()
+    clearIntervalSpy.mockRestore()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest coverage for useRotatingCode hook ensuring codes rotate and interval is cleared

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d01a4f9a88328a0e7483680776d13