### PR TITLE
Add error boundary to guard app render

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 import './theme.css'
 
 // Mount the React application.
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- add ErrorBoundary component with `componentDidCatch` to log errors and show fallback UI
- wrap `<App />` with `<ErrorBoundary>` so rendering errors are handled

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689d01a5ae188328bb3f5cac26830852