### PR TITLE
Guard excel updates when window missing

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,6 +69,9 @@ function loadExcelFiles(changedFilePath) {
  * Send the latest cached Excel data to the renderer.
  */
 function sendExcelUpdate() {
+  if (!win || !win.webContents) {
+    return
+  }
   win.webContents.send('excel-data-updated', cachedData)
 }
 
@@ -132,6 +135,7 @@ function createWindow() {
 
   win.once('ready-to-show', () => {
     win.show()
+    sendExcelUpdate()
   })
 }
 
@@ -142,7 +146,13 @@ if (process.env.NODE_ENV !== 'test') {
     watchExcelFiles()
 
     app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) createWindow()
+      if (BrowserWindow.getAllWindows().length === 0) {
+        createWindow()
+        if (!watcher) {
+          loadExcelFiles()
+          watchExcelFiles()
+        }
+      }
     })
   })
 


### PR DESCRIPTION
## Summary
- Safely send excel updates only when a window and its webContents exist
- Send cached data when a new window is ready and re-establish watchers if missing

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689e398bec6c8328b69c42a796cb9740