### PR TITLE
Add cleanup and error handling to Excel file watcher

### DIFF
--- a/main.test.js
+++ b/main.test.js
@@ -21,16 +21,17 @@ beforeEach(() => {
     on: (event, handler) => {
       handlerMap[event] = handler
     },
+    close: vi.fn(),
   }
   vi.useFakeTimers()
 })
 
-describe('watchExcelFiles debounce', () => {
+describe('watchExcelFiles', () => {
   it('debounces change events', () => {
     const sendSpy = vi.fn()
     main.__setWin({ webContents: { send: sendSpy } })
 
-    main.watchExcelFiles(fakeWatcher)
+    const cleanup = main.watchExcelFiles(fakeWatcher)
     handlerMap.change('file1')
     handlerMap.change('file2')
     handlerMap.change('file3')
@@ -38,13 +39,14 @@ describe('watchExcelFiles debounce', () => {
     vi.advanceTimersByTime(300)
 
     expect(sendSpy).toHaveBeenCalledTimes(1)
+    cleanup()
   })
 
   it('debounces unlink events', () => {
     const sendSpy = vi.fn()
     main.__setWin({ webContents: { send: sendSpy } })
 
-    main.watchExcelFiles(fakeWatcher)
+    const cleanup = main.watchExcelFiles(fakeWatcher)
     handlerMap.unlink('file1')
     handlerMap.unlink('file2')
     handlerMap.unlink('file3')
@@ -52,5 +54,28 @@ describe('watchExcelFiles debounce', () => {
     vi.advanceTimersByTime(300)
 
     expect(sendSpy).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('returns a cleanup function that closes the watcher', () => {
+    const cleanup = main.watchExcelFiles(fakeWatcher)
+    cleanup()
+    expect(fakeWatcher.close).toHaveBeenCalled()
+  })
+
+  it('closes the existing watcher when called again', () => {
+    const firstWatcher = { on: vi.fn(), close: vi.fn() }
+    const secondWatcher = { on: vi.fn(), close: vi.fn() }
+    main.watchExcelFiles(firstWatcher)
+    const cleanup = main.watchExcelFiles(secondWatcher)
+    expect(firstWatcher.close).toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('closes the watcher on error', () => {
+    const cleanup = main.watchExcelFiles(fakeWatcher)
+    handlerMap.error(new Error('fail'))
+    expect(fakeWatcher.close).toHaveBeenCalled()
+    cleanup()
   })
 })


### PR DESCRIPTION
## Summary
- Close existing watcher before creating a new one and expose a cleanup function to stop watching.
- Ensure watcher errors trigger cleanup to avoid dangling listeners.
- Expand tests for new watcher cleanup and error handling behaviors.

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689e398c68048328a1e32f527c0fc30e