### PR TITLE
Validate protocols for external links

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,6 +109,24 @@ function watchExcelFiles(testWatcher) {
 }
 
 /**
+ * Validate an external URL and open it if allowed.
+ *
+ * @param {string} url
+ */
+async function safeOpenExternalLink(url) {
+  try {
+    const parsed = new URL(url)
+    if (['http:', 'https:'].includes(parsed.protocol)) {
+      await shell.openExternal(url)
+      return
+    }
+  } catch {
+    // fall through to error
+  }
+  console.error(`Blocked external URL: ${url}`)
+}
+
+/**
  * Create the main browser window.
  */
 function createWindow() {
@@ -166,9 +184,7 @@ if (process.env.NODE_ENV !== 'test') {
   })
 
   ipcMain.handle('open-external-link', async (_event, url) => {
-    if (url) {
-      await shell.openExternal(url)
-    }
+    await safeOpenExternalLink(url)
   })
 }
 
@@ -178,5 +194,5 @@ module.exports = {
   __setWin: (w) => (win = w),
   __setCachedData: (data) => (cachedData = data),
   getCachedData: () => cachedData,
-  __testables: { loadExcelFiles, sendExcelUpdate },
+  __testables: { loadExcelFiles, sendExcelUpdate, safeOpenExternalLink },
 }

--- a/main.test.js
+++ b/main.test.js
@@ -54,3 +54,26 @@ describe('watchExcelFiles debounce', () => {
     expect(sendSpy).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('safeOpenExternalLink', () => {
+  it('allows http and https URLs', async () => {
+    electronStub.shell.openExternal.mockClear()
+
+    await main.__testables.safeOpenExternalLink('https://example.com')
+    await main.__testables.safeOpenExternalLink('http://example.com')
+
+    expect(electronStub.shell.openExternal).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks other protocols and invalid URLs', async () => {
+    electronStub.shell.openExternal.mockClear()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main.__testables.safeOpenExternalLink('file:///etc/passwd')
+    await main.__testables.safeOpenExternalLink('notaurl')
+
+    expect(electronStub.shell.openExternal).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledTimes(2)
+    errorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- parse and validate URLs before opening external links, restricting protocols to HTTP/HTTPS and logging blocked attempts
- hook IPC `open-external-link` into the new validator and expose it for tests
- cover allowed and disallowed URLs with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e398d07088328a2858150ac05c17e