### PR TITLE
feat: stronger rotating code randomness

### DIFF
--- a/src/hooks/useRotatingCode.js
+++ b/src/hooks/useRotatingCode.js
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
+import crypto from 'crypto'
 
 /**
  * Generate a rotating five digit code that updates on an interval.
+ * Uses Node's crypto.randomInt for stronger randomness.
  * @param {number} intervalMs - Duration in milliseconds before the code rotates.
  * @returns {{currentCode: string, previousCode: string, progressKey: number}}
  */
@@ -12,7 +14,7 @@ const useRotatingCode = (intervalMs = 5 * 60 * 1000) => {
   const codeRef = useRef('')
 
   const generateCode = useCallback(
-    () => Math.floor(10000 + Math.random() * 90000).toString(),
+    () => crypto.randomInt(10000, 100000).toString(),
     []
   )
 

--- a/src/hooks/useRotatingCode.test.js
+++ b/src/hooks/useRotatingCode.test.js
@@ -1,15 +1,16 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import crypto from 'crypto'
 import useRotatingCode from './useRotatingCode'
 
 describe('useRotatingCode', () => {
   it('rotates code and clears interval on unmount', () => {
     vi.useFakeTimers()
     const clearIntervalSpy = vi.spyOn(global, 'clearInterval')
-    const randomMock = vi
-      .spyOn(Math, 'random')
-      .mockReturnValueOnce(0.1)
-      .mockReturnValue(0.2)
+    const randomIntMock = vi
+      .spyOn(crypto, 'randomInt')
+      .mockReturnValueOnce(19000)
+      .mockReturnValue(28000)
 
     const { result, unmount } = renderHook(() => useRotatingCode(1000))
 
@@ -25,7 +26,7 @@ describe('useRotatingCode', () => {
     unmount()
     expect(clearIntervalSpy).toHaveBeenCalled()
 
-    randomMock.mockRestore()
+    randomIntMock.mockRestore()
     clearIntervalSpy.mockRestore()
     vi.useRealTimers()
   })


### PR DESCRIPTION
## Summary
- use crypto.randomInt to generate rotating codes with stronger randomness
- stub crypto.randomInt in hook tests
- document crypto-based randomness in useRotatingCode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e39919c0083289e6e28cd64b0d325