### PR TITLE
Add ARIA attributes to CodeDisplay progress bar

### DIFF
--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 /**
  * Displays the current one-time code and a progress bar indicating
@@ -9,7 +9,24 @@ import React from 'react'
  * @param {number} props.progressKey - Forces animation restart when code updates.
  * @param {number} props.intervalMs - Duration of code validity in ms.
  */
-const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => (
+const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    setProgress(0)
+    const start = Date.now()
+    const id = setInterval(() => {
+      const elapsed = Date.now() - start
+      const percent = Math.min(100, (elapsed / intervalMs) * 100)
+      setProgress(percent)
+      if (elapsed >= intervalMs) {
+        clearInterval(id)
+      }
+    }, 100)
+    return () => clearInterval(id)
+  }, [progressKey, intervalMs])
+
+  return (
     <div className="text-center">
       <div className="large-bold">
         Code: {currentCode}
@@ -17,14 +34,21 @@ const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => 
       <div className="small-muted">
         Prev: {previousCode || 'N/A'}
       </div>
-      <div className="progress-container">
       <div
-        key={progressKey}
-        className="progress-bar"
-        style={{ '--duration': `${intervalMs}ms` }}
-      />
+        className="progress-container"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow={progress}
+      >
+        <div
+          key={progressKey}
+          className="progress-bar"
+          style={{ '--duration': `${intervalMs}ms` }}
+        />
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default CodeDisplay

--- a/src/components/CodeDisplay.test.jsx
+++ b/src/components/CodeDisplay.test.jsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import CodeDisplay from './CodeDisplay'
 
@@ -15,5 +15,28 @@ describe('CodeDisplay progress', () => {
     )
     const bar = container.querySelector('.progress-bar')
     expect(bar.style.getPropertyValue('--duration')).toBe('1000ms')
+  })
+
+  it('sets ARIA progress attributes and updates value', () => {
+    vi.useFakeTimers()
+    const { container } = render(
+      <CodeDisplay
+        currentCode="12345"
+        previousCode="54321"
+        progressKey={1}
+        intervalMs={1000}
+      />
+    )
+    const progress = container.querySelector('.progress-container')
+    expect(progress).toHaveAttribute('role', 'progressbar')
+    expect(progress).toHaveAttribute('aria-valuemin', '0')
+    expect(progress).toHaveAttribute('aria-valuemax', '100')
+    expect(progress).toHaveAttribute('aria-valuenow', '0')
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    const value = Number(progress.getAttribute('aria-valuenow'))
+    expect(value).toBeGreaterThan(0)
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary
- Add ARIA attributes to progress container including role, min, max, and dynamic `aria-valuenow`
- Track progress state to update `aria-valuenow` based on interval
- Test ARIA attributes and progress value updates

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689e39923d808328a48e4f5f7304656f