### PR TITLE
Handle missing Excel files gracefully

### DIFF
--- a/loadExcelFiles.test.js
+++ b/loadExcelFiles.test.js
@@ -64,4 +64,34 @@ describe('incremental Excel loading', () => {
     // Contact data reflects new file
     expect(updated.contactData).toEqual([{ Name: 'Bob', Email: 'bob@example.com' }])
   })
+
+  it('retains cached data when groups file is missing', () => {
+    const initial = getCachedData()
+    fs.unlinkSync(groupsPath)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    loadExcelFiles(groupsPath)
+
+    const updated = getCachedData()
+    expect(updated.emailData).toEqual(initial.emailData)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('groups.xlsx not found')
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('retains cached data when contacts file is missing', () => {
+    const initial = getCachedData()
+    fs.unlinkSync(contactsPath)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    loadExcelFiles(contactsPath)
+
+    const updated = getCachedData()
+    expect(updated.contactData).toEqual(initial.contactData)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('contacts.xlsx not found')
+    )
+    warnSpy.mockRestore()
+  })
 })

--- a/main.js
+++ b/main.js
@@ -42,26 +42,32 @@ const getExcelPaths = () => ({
 function loadExcelFiles(changedFilePath) {
   const { groupsPath, contactsPath } = getExcelPaths()
 
-  try {
-    if (!changedFilePath || changedFilePath === groupsPath) {
-      const groupWorkbook = xlsx.readFile(groupsPath)
-      const groupSheet = groupWorkbook.Sheets[groupWorkbook.SheetNames[0]]
-      cachedData.emailData = xlsx.utils.sheet_to_json(groupSheet, { header: 1 })
+  if (!changedFilePath || changedFilePath === groupsPath) {
+    if (fs.existsSync(groupsPath)) {
+      try {
+        const groupWorkbook = xlsx.readFile(groupsPath)
+        const groupSheet = groupWorkbook.Sheets[groupWorkbook.SheetNames[0]]
+        cachedData.emailData = xlsx.utils.sheet_to_json(groupSheet, { header: 1 })
+      } catch (err) {
+        console.error('Error reading groups file:', err)
+      }
+    } else {
+      console.warn('groups.xlsx not found; using cached group data')
     }
-  } catch (err) {
-    console.error('Error reading groups file:', err)
-    cachedData.emailData = []
   }
 
-  try {
-    if (!changedFilePath || changedFilePath === contactsPath) {
-      const contactWorkbook = xlsx.readFile(contactsPath)
-      const contactSheet = contactWorkbook.Sheets[contactWorkbook.SheetNames[0]]
-      cachedData.contactData = xlsx.utils.sheet_to_json(contactSheet)
+  if (!changedFilePath || changedFilePath === contactsPath) {
+    if (fs.existsSync(contactsPath)) {
+      try {
+        const contactWorkbook = xlsx.readFile(contactsPath)
+        const contactSheet = contactWorkbook.Sheets[contactWorkbook.SheetNames[0]]
+        cachedData.contactData = xlsx.utils.sheet_to_json(contactSheet)
+      } catch (err) {
+        console.error('Error reading contacts file:', err)
+      }
+    } else {
+      console.warn('contacts.xlsx not found; using cached contact data')
     }
-  } catch (err) {
-    console.error('Error reading contacts file:', err)
-    cachedData.contactData = []
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure `groups.xlsx` and `contacts.xlsx` exist before reading, retaining cached data and warning if missing
- Test that cached data persists when Excel files are removed

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689e398c03888328b932c0614f2e1687