### PR TITLE
Add Dispatcher Radar tab with embedded intranet page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import ContactSearch from './components/ContactSearch'
 import CodeDisplay from './components/CodeDisplay'
 import TabSelector from './components/TabSelector'
 import WeatherClock from './components/WeatherClock'
+import DispatcherRadar from './components/DispatcherRadar'
 import { Toaster, toast } from 'react-hot-toast'
 import useRotatingCode from './hooks/useRotatingCode'
 
@@ -209,8 +210,10 @@ function App() {
             setSelectedGroups={setSelectedGroups}
             setAdhocEmails={setAdhocEmails}
           />
-        ) : (
+        ) : tab === 'contact' ? (
           <ContactSearch contactData={contactData} addAdhocEmail={addAdhocEmail} />
+        ) : (
+          <DispatcherRadar />
         )}
       </div>
     </div>

--- a/src/components/DispatcherRadar.jsx
+++ b/src/components/DispatcherRadar.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+
+/**
+ * Embeds the Dispatcher Radar page and provides a fallback if it fails to load.
+ */
+const DispatcherRadar = () => {
+  const [error, setError] = useState(false)
+
+  const iframeStyle = {
+    width: '100%',
+    height: '100%',
+    border: '1px solid var(--border-color)',
+    borderRadius: '4px',
+    background: 'var(--bg-secondary)',
+  }
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      {error ? (
+        <div className="text-center" style={{ padding: '1rem' }}>
+          <p className="mb-1">Unable to load Dispatcher Radar.</p>
+          <a
+            href="https://cw-intra-web/CWDashboard/Home/Radar"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn"
+          >
+            Open Dispatcher Radar
+          </a>
+        </div>
+      ) : (
+        <iframe
+          src="https://cw-intra-web/CWDashboard/Home/Radar"
+          title="Dispatcher Radar"
+          style={iframeStyle}
+          onError={() => setError(true)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default DispatcherRadar

--- a/src/components/TabSelector.jsx
+++ b/src/components/TabSelector.jsx
@@ -3,28 +3,32 @@ import React from 'react'
 /**
  * Renders the Email/Contact tab selector.
  * @param {Object} props
- * @param {'email'|'contact'} props.tab - Currently active tab.
+ * @param {'email'|'contact'|'radar'} props.tab - Currently active tab.
  * @param {(tab: string) => void} props.setTab - Update active tab.
  */
-  const TabSelector = ({ tab, setTab }) => (
-    <div className="stack-on-small tab-selector">
-      {['email', 'contact'].map((t) => (
-        <button
-          key={t}
-          type="button"
-          onClick={() => setTab(t)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              setTab(t)
-            }
-          }}
-          className={`tab-button ${tab === t ? 'active' : ''}`}
-        >
-          {t === 'email' ? 'Email Groups' : 'Contact Search'}
-        </button>
-      ))}
-    </div>
+const TabSelector = ({ tab, setTab }) => (
+  <div className="stack-on-small tab-selector">
+    {['email', 'contact', 'radar'].map((t) => (
+      <button
+        key={t}
+        type="button"
+        onClick={() => setTab(t)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setTab(t)
+          }
+        }}
+        className={`tab-button ${tab === t ? 'active' : ''}`}
+      >
+        {t === 'email'
+          ? 'Email Groups'
+          : t === 'contact'
+          ? 'Contact Search'
+          : 'Dispatcher Radar'}
+      </button>
+    ))}
+  </div>
 )
 
 export default TabSelector


### PR DESCRIPTION
## Summary
- add Dispatcher Radar tab to the header
- embed intranet radar page with styled fallback link

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a623d3db7c8328848a2ff335f1e2b8