### PR TITLE
Embed Dispatcher Radar tab and fix crypto usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet" crossorigin integrity="sha384-zs/+51w+65bsBoYddfdz0w9ZCWoi/j91AcE9T55Kr6dt7PtE1TbzaiSz7aqBtQp0">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <title>NOC List</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import ContactSearch from './components/ContactSearch'
 import CodeDisplay from './components/CodeDisplay'
 import TabSelector from './components/TabSelector'
 import WeatherClock from './components/WeatherClock'
+import DispatcherRadar from './components/DispatcherRadar'
 import { Toaster, toast } from 'react-hot-toast'
 import useRotatingCode from './hooks/useRotatingCode'
 
@@ -189,6 +190,7 @@ function App() {
         </div>
         <TabSelector tab={tab} setTab={setTab} />
 
+        {tab !== 'radar' && (
           <div className="stack-on-small gap-1 mb-1">
             <button onClick={refreshData} className="btn">
               Refresh Data
@@ -197,6 +199,7 @@ function App() {
               Last Refreshed: {lastRefresh}
             </span>
           </div>
+        )}
       </header>
 
       {/* Scrollable content area */}
@@ -209,9 +212,12 @@ function App() {
             setSelectedGroups={setSelectedGroups}
             setAdhocEmails={setAdhocEmails}
           />
-        ) : (
+        ) : tab === 'contact' ? (
           <ContactSearch contactData={contactData} addAdhocEmail={addAdhocEmail} />
-        )}
+        ) : null}
+        <div style={{ display: tab === 'radar' ? 'block' : 'none', height: '100%' }}>
+          <DispatcherRadar />
+        </div>
       </div>
     </div>
   )

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import App from './App'
@@ -14,6 +14,7 @@ beforeEach(() => {
 afterEach(() => {
   global.fetch = originalFetch
   window.nocListAPI = originalNocListAPI
+  cleanup()
 })
 
 describe('App', () => {
@@ -43,6 +44,52 @@ describe('App', () => {
     }
     render(<App />)
     expect(await screen.findByAltText('NOC List Logo')).toBeInTheDocument()
+  })
+
+  it('preserves Dispatcher Radar iframe across tab switches', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
+    )
+    window.nocListAPI = {
+      loadExcelData: async () => ({ emailData: [], contactData: [] }),
+      onExcelDataUpdate: () => () => {},
+      onExcelWatchError: () => () => {},
+    }
+    render(<App />)
+
+    const radarButton = screen.getByRole('button', { name: 'Dispatcher Radar' })
+    fireEvent.click(radarButton)
+    const iframe = screen.getByTitle('Dispatcher Radar')
+
+    const emailButton = screen.getByRole('button', { name: 'Email Groups' })
+    fireEvent.click(emailButton)
+    fireEvent.click(radarButton)
+
+    expect(screen.getByTitle('Dispatcher Radar')).toBe(iframe)
+  })
+
+  it('hides refresh controls on Dispatcher Radar tab', () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
+    )
+    window.nocListAPI = {
+      loadExcelData: async () => ({ emailData: [], contactData: [] }),
+      onExcelDataUpdate: () => () => {},
+      onExcelWatchError: () => () => {},
+    }
+    render(<App />)
+
+    const radarButton = screen.getByRole('button', { name: 'Dispatcher Radar' })
+    fireEvent.click(radarButton)
+
+    expect(screen.queryByRole('button', { name: 'Refresh Data' })).toBeNull()
+    expect(screen.queryByText(/Last Refreshed/)).toBeNull()
+
+    const emailButton = screen.getByRole('button', { name: 'Email Groups' })
+    fireEvent.click(emailButton)
+
+    expect(screen.getByRole('button', { name: 'Refresh Data' })).toBeInTheDocument()
+    expect(screen.getByText(/Last Refreshed/)).toBeInTheDocument()
   })
 })
 

--- a/src/components/DispatcherRadar.jsx
+++ b/src/components/DispatcherRadar.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+
+/**
+ * Embeds the Dispatcher Radar page and provides a fallback if it fails to load.
+ */
+const DispatcherRadar = () => {
+  const [error, setError] = useState(false)
+
+  const iframeStyle = {
+    width: '100%',
+    height: '100%',
+    border: '1px solid var(--border-color)',
+    borderRadius: '4px',
+    background: 'var(--bg-secondary)',
+  }
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      {error ? (
+        <div className="text-center" style={{ padding: '1rem' }}>
+          <p className="mb-1">Unable to load Dispatcher Radar.</p>
+          <a
+            href="https://cw-intra-web/CWDashboard/Home/Radar"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn"
+          >
+            Open Dispatcher Radar
+          </a>
+        </div>
+      ) : (
+        <iframe
+          src="https://cw-intra-web/CWDashboard/Home/Radar"
+          title="Dispatcher Radar"
+          style={iframeStyle}
+          onError={() => setError(true)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default DispatcherRadar

--- a/src/components/TabSelector.jsx
+++ b/src/components/TabSelector.jsx
@@ -3,28 +3,32 @@ import React from 'react'
 /**
  * Renders the Email/Contact tab selector.
  * @param {Object} props
- * @param {'email'|'contact'} props.tab - Currently active tab.
+ * @param {'email'|'contact'|'radar'} props.tab - Currently active tab.
  * @param {(tab: string) => void} props.setTab - Update active tab.
  */
-  const TabSelector = ({ tab, setTab }) => (
-    <div className="stack-on-small tab-selector">
-      {['email', 'contact'].map((t) => (
-        <button
-          key={t}
-          type="button"
-          onClick={() => setTab(t)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              setTab(t)
-            }
-          }}
-          className={`tab-button ${tab === t ? 'active' : ''}`}
-        >
-          {t === 'email' ? 'Email Groups' : 'Contact Search'}
-        </button>
-      ))}
-    </div>
+const TabSelector = ({ tab, setTab }) => (
+  <div className="stack-on-small tab-selector">
+    {['email', 'contact', 'radar'].map((t) => (
+      <button
+        key={t}
+        type="button"
+        onClick={() => setTab(t)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setTab(t)
+          }
+        }}
+        className={`tab-button ${tab === t ? 'active' : ''}`}
+      >
+        {t === 'email'
+          ? 'Email Groups'
+          : t === 'contact'
+          ? 'Contact Search'
+          : 'Dispatcher Radar'}
+      </button>
+    ))}
+  </div>
 )
 
 export default TabSelector

--- a/src/hooks/useRotatingCode.js
+++ b/src/hooks/useRotatingCode.js
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import crypto from 'crypto'
 
 /**
  * Generate a rotating five digit code that updates on an interval.
- * Uses Node's crypto.randomInt for stronger randomness.
+ * Generates codes using Web Crypto when available.
  * @param {number} intervalMs - Duration in milliseconds before the code rotates.
  * @returns {{currentCode: string, previousCode: string, progressKey: number}}
  */
@@ -13,10 +12,14 @@ const useRotatingCode = (intervalMs = 5 * 60 * 1000) => {
   const [progressKey, setProgressKey] = useState(Date.now())
   const codeRef = useRef('')
 
-  const generateCode = useCallback(
-    () => crypto.randomInt(10000, 100000).toString(),
-    []
-  )
+  const generateCode = useCallback(() => {
+    if (globalThis.crypto?.getRandomValues) {
+      const array = new Uint32Array(1)
+      globalThis.crypto.getRandomValues(array)
+      return (10000 + (array[0] % 90000)).toString().padStart(5, '0')
+    }
+    return Math.floor(10000 + Math.random() * 90000).toString()
+  }, [])
 
   useEffect(() => {
     const newCode = generateCode()

--- a/src/hooks/useRotatingCode.test.js
+++ b/src/hooks/useRotatingCode.test.js
@@ -1,16 +1,21 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import crypto from 'crypto'
 import useRotatingCode from './useRotatingCode'
 
 describe('useRotatingCode', () => {
   it('rotates code and clears interval on unmount', () => {
     vi.useFakeTimers()
     const clearIntervalSpy = vi.spyOn(global, 'clearInterval')
-    const randomIntMock = vi
-      .spyOn(crypto, 'randomInt')
-      .mockReturnValueOnce(19000)
-      .mockReturnValue(28000)
+    const getRandomValuesMock = vi
+      .spyOn(globalThis.crypto, 'getRandomValues')
+      .mockImplementationOnce((arr) => {
+        arr[0] = 9000
+        return arr
+      })
+      .mockImplementation((arr) => {
+        arr[0] = 18000
+        return arr
+      })
 
     const { result, unmount } = renderHook(() => useRotatingCode(1000))
 
@@ -26,7 +31,7 @@ describe('useRotatingCode', () => {
     unmount()
     expect(clearIntervalSpy).toHaveBeenCalled()
 
-    randomIntMock.mockRestore()
+    getRandomValuesMock.mockRestore()
     clearIntervalSpy.mockRestore()
     vi.useRealTimers()
   })


### PR DESCRIPTION
## Summary
- remove invalid integrity attribute for Google Fonts link
- use Web Crypto to generate rotating codes in browser-friendly way
- embed Dispatcher Radar page with fallback and keep iframe mounted across tab switches
- add regression test ensuring Dispatcher Radar persists when navigating tabs
- hide refresh controls when viewing Dispatcher Radar tab
- resolve lingering App.jsx conflict by aligning tab content rendering while keeping radar iframe mounted

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a623d3db7c8328848a2ff335f1e2b8