### PR TITLE
feat: add minimal scrollbar styling to radar embed

### DIFF
--- a/src/components/DispatcherRadar.jsx
+++ b/src/components/DispatcherRadar.jsx
@@ -33,6 +33,7 @@ const DispatcherRadar = () => {
           src="https://cw-intra-web/CWDashboard/Home/Radar"
           title="Dispatcher Radar"
           style={iframeStyle}
+          className="minimal-scrollbar"
           onError={() => setError(true)}
         />
       )}

--- a/src/theme.css
+++ b/src/theme.css
@@ -253,6 +253,27 @@ a[href^="mailto:"]:hover {
   opacity: 0.5;
 }
 
+/* Utility class for applying minimal scrollbars to embedded content */
+.minimal-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) transparent;
+}
+
+.minimal-scrollbar::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+.minimal-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.minimal-scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--accent);
+  border-radius: 4px;
+  opacity: 0.5;
+}
+
 /* Progress bar for code timer */
 .progress-container {
   position: relative;


### PR DESCRIPTION
## Summary
- ensure dispatcher radar iframe uses app's minimal scrollbar style
- add reusable `minimal-scrollbar` utility class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65310e9408328a5436aec6746973e