### PR TITLE
Virtualize email group list and debounce search input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-hot-toast": "^2.4.0",
+        "react-window": "^1.8.11",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -295,7 +296,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3740,6 +3740,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -4257,6 +4263,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react-dom": "^18.0.0",
     "react-hot-toast": "^2.4.0",
     "xlsx": "^0.18.5",
-    "chokidar": "^3.6.0"
+    "chokidar": "^3.6.0",
+    "react-window": "^1.8.11"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/components/EmailGroups.test.jsx
+++ b/src/components/EmailGroups.test.jsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { render, screen, fireEvent, act, within } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import EmailGroups from './EmailGroups'
 
@@ -22,5 +23,69 @@ describe('EmailGroups', () => {
     )
     expect(screen.getByRole('button', { name: /Group A \(2\)/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Group B \(1\)/ })).toBeInTheDocument()
+  })
+
+  it('debounces search input', () => {
+    vi.useFakeTimers()
+    render(
+      <EmailGroups
+        emailData={sampleData}
+        adhocEmails={[]}
+        selectedGroups={[]}
+        setSelectedGroups={() => {}}
+        setAdhocEmails={() => {}}
+      />
+    )
+
+    const search = screen.getAllByPlaceholderText(/Search groups/i)[0]
+    fireEvent.change(search, { target: { value: 'Group B' } })
+
+    // Immediately after typing, both buttons still visible
+    expect(
+      screen.getAllByRole('button', { name: /Group A \(2\)/ })[0]
+    ).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    // After debounce, only Group B remains
+    const list = screen.getAllByTestId('group-list').pop()
+    const groupButtonsAfter = within(list).getAllByRole('button')
+    expect(
+      groupButtonsAfter.some(btn => btn.textContent.includes('Group B'))
+    ).toBe(true)
+
+    vi.useRealTimers()
+  })
+
+  it('maintains selection and clear all with virtualization', () => {
+    const Wrapper = () => {
+      const [selectedGroups, setSelectedGroups] = React.useState([])
+      const [adhocEmails, setAdhocEmails] = React.useState(['x@example.com'])
+      return (
+        <EmailGroups
+          emailData={sampleData}
+          adhocEmails={adhocEmails}
+          selectedGroups={selectedGroups}
+          setSelectedGroups={setSelectedGroups}
+          setAdhocEmails={setAdhocEmails}
+        />
+      )
+    }
+
+    render(<Wrapper />)
+    const groupButtons = screen.getAllByRole('button', {
+      name: /Group A \(2\)/,
+    })
+    fireEvent.click(groupButtons[0])
+    expect(
+      screen.getByRole('button', { name: /Clear All/ })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear All/ }))
+    expect(
+      screen.queryByRole('button', { name: /Clear All/ })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+export default function useDebounce(value, delay = 300) {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(handler)
+  }, [value, delay])
+
+  return debounced
+}

--- a/src/hooks/useDebounce.test.js
+++ b/src/hooks/useDebounce.test.js
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import useDebounce from './useDebounce'
+
+describe('useDebounce', () => {
+  it('delays updating the value', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'a' }
+    })
+
+    expect(result.current).toBe('a')
+
+    rerender({ value: 'abc' })
+    // Still old value before debounce time
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(result.current).toBe('abc')
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- Render email groups with `react-window` to virtualize the list and keep only visible buttons in the DOM
- Debounce the group search input using a reusable `useDebounce` hook
- Add regression tests confirming debounce behavior and Clear All functionality with virtualization

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bf2ed2693883288f156ccbedc79399