### PR TITLE
refine button layout and contact cards

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -124,6 +124,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
             itemSize={150}
             width={'100%'}
             ref={listRef}
+            className="minimal-scrollbar"
           >
             {({ index, style }) => {
               const contact = filtered[index]

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -149,6 +149,7 @@ const EmailGroups = ({
             itemCount={filteredGroups.length}
             itemSize={40}
             width="100%"
+            className="minimal-scrollbar"
           >
             {({ index, style }) => {
               const group = filteredGroups[index]
@@ -180,7 +181,7 @@ const EmailGroups = ({
 
       {mergedEmails.length > 0 && (
         <>
-            <div className="flex gap-0-5 mb-0-5">
+            <div className="flex flex-wrap gap-0-5 mb-0-5">
               <button onClick={copyToClipboard} className="btn fade-in">
                 Copy Email List
               </button>

--- a/src/theme.css
+++ b/src/theme.css
@@ -27,7 +27,7 @@ body {
 .btn {
   padding: 0.5rem 1rem;
   margin: 0.25rem;
-  border: none;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   background: var(--button-bg);
   color: var(--button-text);
@@ -39,8 +39,7 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 1 1 auto;
-  max-width: 100%;
+  flex: 0 0 auto;
 }
 
 .btn:hover {
@@ -174,14 +173,15 @@ body {
 .contact-card {
   background: var(--bg-secondary);
   padding: 1rem;
-  border-radius: 6px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
   color: var(--text-light);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   animation: fade-in 0.3s ease;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.5rem;
   max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- prevent refresh button from stretching full width and allow action buttons to wrap
- modernize shared button style and add borders to contact cards
- apply minimal scrollbars to group and contact lists

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c0854b26ac83289669de377cf3345f