### PR TITLE
Refine UI layouts and radar presentation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -144,14 +144,19 @@ function App() {
               </p>
             </div>
           </div>
-          <div className="app-meta-card">
-            <CodeDisplay
-              currentCode={currentCode}
-              previousCode={previousCode}
-              progressKey={progressKey}
-              intervalMs={intervalMs}
-            />
-            <WeatherClock />
+          <div className="app-meta-card status-panel">
+            <div className="status-panel__block">
+              <CodeDisplay
+                currentCode={currentCode}
+                previousCode={previousCode}
+                progressKey={progressKey}
+                intervalMs={intervalMs}
+              />
+            </div>
+            <div className="status-panel__divider" aria-hidden="true" />
+            <div className="status-panel__block">
+              <WeatherClock />
+            </div>
           </div>
         </div>
 

--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -34,12 +34,12 @@ const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => 
 
   return (
     <div className="code-display">
-      <div className="small-text text-muted">Current Code</div>
+      <div className="code-display__meta">
+        <span className="small-text text-muted">Current Code</span>
+        <span className="small-muted">Prev: {previousCode || 'N/A'}</span>
+      </div>
       <div className="large-bold" aria-live="polite">
         {currentCode}
-      </div>
-      <div className="small-muted">
-        Previous: {previousCode || 'N/A'}
       </div>
       <div
         className="progress-container"

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -21,6 +21,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
   const itemRefs = useRef({})
   const [activeIndex, setActiveIndex] = useState(-1)
   const [listHeight, setListHeight] = useState(400)
+  const CONTACT_ITEM_HEIGHT = 220
 
   const indexedContacts = useMemo(
     () =>
@@ -46,7 +47,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
   useEffect(() => {
     const updateHeight = () => {
       const maxHeight = window.innerHeight - 260
-      setListHeight(Math.max(320, maxHeight))
+      setListHeight(Math.max(CONTACT_ITEM_HEIGHT * 1.2, maxHeight))
     }
     updateHeight()
     window.addEventListener('resize', updateHeight)
@@ -79,7 +80,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
       : '?'
 
     return (
-      <div style={{ ...style, padding: '0 0.5rem 1.25rem' }} className="virtual-row">
+      <div style={{ ...style, padding: '0.5rem 0.5rem' }} className="virtual-row">
         <article className="contact-card">
           <div className="contact-card__header">
             <div className="contact-card__avatar">{initials}</div>
@@ -160,7 +161,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
           <List
             height={listHeight}
             itemCount={filtered.length}
-            itemSize={180}
+            itemSize={CONTACT_ITEM_HEIGHT}
             width="100%"
             ref={listRef}
           >

--- a/src/components/DispatcherRadar.jsx
+++ b/src/components/DispatcherRadar.jsx
@@ -21,12 +21,15 @@ const DispatcherRadar = () => {
           </a>
         </div>
       ) : (
-        <iframe
-          src="https://cw-intra-web/CWDashboard/Home/Radar"
-          title="Dispatcher Radar"
-          className="radar-frame minimal-scrollbar"
-          onError={() => setError(true)}
-        />
+        <div className="radar-frame-wrapper minimal-scrollbar">
+          <iframe
+            src="https://cw-intra-web/CWDashboard/Home/Radar"
+            title="Dispatcher Radar"
+            className="radar-frame minimal-scrollbar"
+            onError={() => setError(true)}
+          />
+          <div className="radar-frame-overlay" aria-hidden="true" />
+        </div>
       )}
     </div>
   )

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -105,8 +105,10 @@ const EmailGroups = ({
     toast.success('Opening Teams meeting')
   }, [mergedEmails])
 
+  const GROUP_ITEM_HEIGHT = 72
+
   const listHeight = useMemo(
-    () => Math.min(Math.max(filteredGroups.length * 60, 240), 420),
+    () => Math.min(Math.max(filteredGroups.length * GROUP_ITEM_HEIGHT, 240), 420),
     [filteredGroups.length],
   )
 
@@ -149,12 +151,17 @@ const EmailGroups = ({
 
       <div className="list-surface minimal-scrollbar">
         {filteredGroups.length > 0 ? (
-          <List height={listHeight} itemCount={filteredGroups.length} itemSize={60} width="100%">
+          <List
+            height={listHeight}
+            itemCount={filteredGroups.length}
+            itemSize={GROUP_ITEM_HEIGHT}
+            width="100%"
+          >
             {({ index, style }) => {
               const group = filteredGroups[index]
               return (
                 <div
-                  style={{ ...style, padding: '0 0.25rem 0.65rem' }}
+                  style={{ ...style, padding: '0.35rem 0.25rem' }}
                   className="virtual-button-row"
                 >
                   <button

--- a/src/theme.css
+++ b/src/theme.css
@@ -494,9 +494,76 @@ a[href^="mailto:"]:hover {
   padding: 0.5rem;
 }
 
+.code-display__meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .weather-clock {
   text-align: center;
   line-height: 1.35;
+}
+
+.status-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: center;
+  gap: clamp(1rem, 2vw, 1.75rem);
+  padding: 1rem 1.25rem;
+}
+
+.status-panel__block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.status-panel__divider {
+  display: none;
+  width: 1px;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    rgba(96, 165, 250, 0.45),
+    rgba(37, 99, 235, 0.15)
+  );
+  opacity: 0.6;
+  border-radius: 999px;
+}
+
+.status-panel .code-display,
+.status-panel .weather-clock {
+  padding: 0;
+  text-align: left;
+}
+
+.status-panel .code-display {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.status-panel .weather-clock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  line-height: 1.3;
+}
+
+.status-panel .progress-container {
+  margin-top: 0.35rem;
+}
+
+@media (min-width: 720px) {
+  .status-panel {
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  }
+
+  .status-panel__divider {
+    display: block;
+  }
 }
 
 .radar-container {
@@ -507,12 +574,32 @@ a[href^="mailto:"]:hover {
   gap: 1rem;
 }
 
-.radar-frame {
+
+.radar-frame-wrapper {
+  position: relative;
   flex: 1;
-  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(9, 14, 26, 0.92);
   box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.radar-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+  background: transparent;
+  filter: saturate(0.82) contrast(1.08) brightness(0.92);
+}
+
+.radar-frame-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(13, 19, 32, 0.2), rgba(13, 19, 32, 0.45));
+  mix-blend-mode: soft-light;
 }
 
 .radar-fallback {
@@ -529,8 +616,14 @@ a[href^="mailto:"]:hover {
 }
 
 .virtual-row {
-  padding: 0 0.65rem 1.25rem;
+  padding: 0.5rem;
   box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+}
+
+.virtual-row .contact-card {
+  width: min(100%, 720px);
 }
 
 .contact-card {
@@ -548,6 +641,7 @@ a[href^="mailto:"]:hover {
   padding: 1.35rem;
   box-shadow: var(--shadow-sm);
   overflow: hidden;
+  height: 100%;
 }
 
 .contact-card::before {
@@ -620,6 +714,7 @@ a[href^="mailto:"]:hover {
 .contact-card__actions {
   display: flex;
   justify-content: flex-start;
+  margin-top: auto;
 }
 
 .list-surface {
@@ -633,17 +728,19 @@ a[href^="mailto:"]:hover {
 }
 
 .virtual-button-row {
-  padding: 0 0.25rem 0.65rem;
+  padding: 0.35rem 0.25rem;
   box-sizing: border-box;
+  display: flex;
+  justify-content: center;
 }
 
 .list-item-button {
-  width: 100%;
+  width: min(100%, 520px);
   border-radius: 16px;
   border: 1px solid transparent;
   background: rgba(15, 23, 42, 0.8);
   color: var(--text-light);
-  padding: 0.65rem 1.1rem;
+  padding: 0.55rem 1.1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- compact the header status card by combining the rotating code and weather/time blocks
- adjust the email group list and contact virtualization heights so list items no longer overlap or stretch full width
- wrap the dispatcher radar iframe with a styled shell to add a matching scrollbar treatment and subtle visual filter

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d3369bbf848328bf31855e823d5f7d