### PR TITLE
Improve email list layout and ad-hoc chip management

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react'
 import { toast } from 'react-hot-toast'
-import { FixedSizeList as List } from 'react-window'
 
 /**
  * Manage selection of email groups and creation of merged mailing lists.
@@ -105,11 +104,11 @@ const EmailGroups = ({
     toast.success('Opening Teams meeting')
   }, [mergedEmails])
 
-  const GROUP_ITEM_HEIGHT = 80
-
-  const listHeight = useMemo(
-    () => Math.min(Math.max(filteredGroups.length * GROUP_ITEM_HEIGHT, 240), 420),
-    [filteredGroups.length],
+  const removeAdhocEmail = useCallback(
+    (email) => {
+      setAdhocEmails((prev) => prev.filter((item) => item !== email))
+    },
+    [setAdhocEmails],
   )
 
   return (
@@ -151,32 +150,20 @@ const EmailGroups = ({
 
       <div className="list-surface minimal-scrollbar">
         {filteredGroups.length > 0 ? (
-          <List
-            height={listHeight}
-            itemCount={filteredGroups.length}
-            itemSize={GROUP_ITEM_HEIGHT}
-            width="100%"
-          >
-            {({ index, style }) => {
-              const group = filteredGroups[index]
-              return (
-                <div
-                  style={{ ...style, padding: '0.35rem 0.25rem' }}
-                  className="virtual-button-row"
-                >
-                  <button
-                    onClick={() => toggleSelect(group.name)}
-                    className={`list-item-button ${
-                      selectedGroups.includes(group.name) ? 'is-selected' : ''
-                    }`}
-                  >
-                    <span>{group.name}</span>
-                    <span className="item-count">{group.emails.length} contacts</span>
-                  </button>
-                </div>
-              )
-            }}
-          </List>
+          <div className="group-grid">
+            {filteredGroups.map((group) => (
+              <button
+                key={group.name}
+                onClick={() => toggleSelect(group.name)}
+                className={`list-item-button ${
+                  selectedGroups.includes(group.name) ? 'is-selected' : ''
+                }`}
+              >
+                <span>{group.name}</span>
+                <span className="item-count">{group.emails.length} contacts</span>
+              </button>
+            ))}
+          </div>
         ) : (
           <div className="empty-state">No groups match your search.</div>
         )}
@@ -187,6 +174,33 @@ const EmailGroups = ({
           </button>
         )}
       </div>
+
+      {adhocEmails.length > 0 && (
+        <div className="adhoc-email-panel">
+          <div className="adhoc-email-panel__header">
+            <strong>Ad-hoc Emails</strong>
+            <span className="badge">{adhocEmails.length}</span>
+          </div>
+          <div className="adhoc-email-panel__list">
+            {adhocEmails.map((email) => (
+              <button
+                key={email}
+                type="button"
+                className="adhoc-chip"
+                onClick={() => removeAdhocEmail(email)}
+                title={`Remove ${email}`}
+              >
+                <span className="adhoc-chip__text">{email}</span>
+                <span aria-hidden="true" className="adhoc-chip__remove">
+                  ×
+                </span>
+                <span className="sr-only">Remove {email}</span>
+              </button>
+            ))}
+          </div>
+          <p className="small-muted m-0">Tap an email to remove it from the list.</p>
+        </div>
+      )}
 
       {mergedEmails.length > 0 && (
         <>

--- a/src/components/EmailGroups.test.jsx
+++ b/src/components/EmailGroups.test.jsx
@@ -56,4 +56,30 @@ describe('EmailGroups', () => {
     await user.click(clear)
     expect(screen.getByRole('button', { name: /Group A/i })).not.toHaveClass('is-selected')
   })
+
+  it('shows ad-hoc email chips and allows removing them', async () => {
+    const user = userEvent.setup()
+
+    function Wrapper() {
+      const [selected, setSelected] = useState([])
+      const [adhoc, setAdhoc] = useState(['solo@example.com'])
+      return (
+        <EmailGroups
+          emailData={sampleData}
+          adhocEmails={adhoc}
+          selectedGroups={selected}
+          setSelectedGroups={setSelected}
+          setAdhocEmails={setAdhoc}
+        />
+      )
+    }
+
+    render(<Wrapper />)
+    const removeButton = screen.getByRole('button', { name: /remove solo@example.com/i })
+    expect(removeButton).toBeInTheDocument()
+    await user.click(removeButton)
+    expect(
+      screen.queryByRole('button', { name: /remove solo@example.com/i })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/theme.css
+++ b/src/theme.css
@@ -729,14 +729,14 @@ a[href^="mailto:"]:hover {
   border: 1px solid rgba(148, 163, 184, 0.2);
   padding: 1rem;
   box-shadow: var(--shadow-sm);
+  max-height: min(420px, 60vh);
+  overflow-y: auto;
 }
 
-.virtual-button-row {
-  padding: 0.35rem 0.25rem;
-  box-sizing: border-box;
-  display: flex;
-  justify-content: flex-start;
-  width: 100%;
+.group-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem;
 }
 
 .list-item-button {
@@ -754,10 +754,8 @@ a[href^="mailto:"]:hover {
   transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease;
   font-weight: 600;
   letter-spacing: 0.01em;
-  width: auto;
-  max-width: min(100%, 520px);
-  min-width: min(100%, 280px);
-  align-self: flex-start;
+  width: 100%;
+  min-height: 64px;
 }
 
 .list-item-button span:first-child {
@@ -784,6 +782,86 @@ a[href^="mailto:"]:hover {
   color: var(--text-muted);
   flex: 0 0 auto;
   white-space: nowrap;
+}
+
+.adhoc-email-panel {
+  background: rgba(8, 13, 25, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.adhoc-email-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.2);
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  color: var(--text-light);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.adhoc-email-panel__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.adhoc-chip {
+  border: 1px solid rgba(96, 165, 250, 0.4);
+  background: rgba(37, 56, 92, 0.5);
+  color: var(--text-light);
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, border 0.15s ease, background 0.15s ease;
+}
+
+.adhoc-chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(96, 165, 250, 0.75);
+  background: rgba(59, 86, 128, 0.6);
+}
+
+.adhoc-chip:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.8);
+  outline-offset: 2px;
+}
+
+.adhoc-chip__remove {
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0.75;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .email-actions {


### PR DESCRIPTION
## Summary
- replace the virtualized email group list with a responsive grid layout and tighten spacing
- surface ad-hoc email addresses as removable chips below the group picker
- tweak theme styling to support the new layout and chip presentation
- extend EmailGroups tests to cover the ad-hoc email chip behaviour

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d345f8775883289a90bb9eb52a9aee