### PR TITLE
Improve contact email add flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,29 +81,26 @@ function App() {
       const normalized = cleaned.toLowerCase()
 
       if (!cleaned || !isValidEmail(cleaned)) {
-        toast.error('Invalid email address')
-        return false
+        return 'invalid'
       }
 
-      let added = false
+      /** @type {'added' | 'duplicate'} */
+      let status = 'duplicate'
+
       setAdhocEmails((prev) => {
         if (prev.some((existing) => existing.toLowerCase() === normalized)) {
           return prev
         }
-        added = true
+
+        status = 'added'
         return [...prev, cleaned]
       })
 
-      if (added) {
-        toast.success(`Added ${cleaned}`)
-        if (switchToEmailTab) {
-          setTab('email')
-        }
-      } else {
-        toast('Email already in list', { icon: 'ℹ️' })
+      if (status === 'added' && switchToEmailTab) {
+        setTab('email')
       }
 
-      return added
+      return status
     },
     [isValidEmail, setTab],
   )

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,38 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
+
+vi.mock('react-window', async () => {
+  const React = await import('react')
+  return {
+    FixedSizeList: React.forwardRef(({ children, itemCount, itemSize, height }, ref) => (
+      <div ref={ref} style={{ height, overflowY: 'auto' }}>
+        {Array.from({ length: itemCount }).map((_, index) =>
+          children({ index, style: { height: itemSize, width: '100%' } }),
+        )}
+      </div>
+    )),
+  }
+})
+
+vi.mock('./components/ContactSearch', () => ({
+  __esModule: true,
+  default: ({ addAdhocEmail }) => (
+    <button
+      type="button"
+      onClick={() => addAdhocEmail('test.agent@example.com', { switchToEmailTab: true })}
+    >
+      Mock Add Contact
+    </button>
+  ),
+}))
+
+vi.mock('./components/WeatherClock', () => ({
+  __esModule: true,
+  default: () => <div>Mock Weather</div>,
+}))
+
 import App from './App'
 
 let originalFetch
@@ -9,6 +41,7 @@ let originalNocListAPI
 beforeEach(() => {
   originalFetch = global.fetch
   originalNocListAPI = window.nocListAPI
+  localStorage.clear()
 })
 
 afterEach(() => {
@@ -42,6 +75,54 @@ describe('App', () => {
     }
     render(<App />)
     expect(await screen.findByAltText(/noc list logo/i)).toBeInTheDocument()
+})
+
+  it('adds a contact email to the ad-hoc list from contact search', async () => {
+    const user = userEvent.setup()
+
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
+    )
+
+    const loadExcelData = vi.fn().mockResolvedValue({
+      emailData: [
+        ['Group A'],
+        ['group@example.com'],
+      ],
+      contactData: [
+        {
+          Name: 'Test Agent',
+          Email: 'test.agent@example.com',
+          Phone: '555-0000',
+        },
+      ],
+    })
+
+    window.nocListAPI = {
+      loadExcelData,
+      onExcelDataUpdate: () => () => {},
+      onExcelWatchError: () => () => {},
+      openFile: () => {},
+      openExternal: () => {},
+    }
+
+    render(<App />)
+
+    const [contactTab] = await screen.findAllByRole('tab', { name: /contact search/i })
+    await user.click(contactTab)
+
+    const addButton = await screen.findByRole('button', { name: /mock add contact/i })
+
+    await user.click(addButton)
+
+    const [emailTab] = await screen.findAllByRole('tab', { name: /email groups/i })
+    await waitFor(() => expect(emailTab).toHaveAttribute('aria-selected', 'true'))
+
+    expect(
+      await screen.findByRole('button', { name: /remove test\.agent@example\.com/i })
+    ).toBeInTheDocument()
+
+    await new Promise((resolve) => setTimeout(resolve, 350))
   })
 })
 

--- a/src/components/ContactSearch.test.jsx
+++ b/src/components/ContactSearch.test.jsx
@@ -15,7 +15,7 @@ afterEach(() => cleanup())
 describe('ContactSearch', () => {
   it('filters contacts without crashing on non-string values', () => {
     render(
-      <ContactSearch contactData={contacts} addAdhocEmail={() => {}} />
+      <ContactSearch contactData={contacts} addAdhocEmail={() => 'added'} />
     )
     const input = screen.getByPlaceholderText(/search contacts/i)
     fireEvent.change(input, { target: { value: 'Agent 1' } })
@@ -24,14 +24,14 @@ describe('ContactSearch', () => {
 
   it('virtualizes the contact list', () => {
     render(
-      <ContactSearch contactData={contacts} addAdhocEmail={() => {}} />
+      <ContactSearch contactData={contacts} addAdhocEmail={() => 'added'} />
     )
     const buttons = screen.getAllByText(/add to email list/i)
     expect(buttons.length).toBeLessThan(contacts.length)
   })
 
   it('supports keyboard navigation and add action', () => {
-    const add = vi.fn()
+    const add = vi.fn(() => 'added')
     render(<ContactSearch contactData={contacts} addAdhocEmail={add} />)
     const input = screen.getByPlaceholderText(/search contacts/i)
     fireEvent.keyDown(input, { key: 'ArrowDown' })
@@ -42,5 +42,22 @@ describe('ContactSearch', () => {
     expect(secondBtn).toHaveFocus()
     fireEvent.click(secondBtn)
     expect(add).toHaveBeenCalledWith('agent1@example.com', { switchToEmailTab: true })
+  })
+
+  it('extracts email from complex fields when adding to the list', () => {
+    const add = vi.fn(() => 'added')
+    const complexContacts = [
+      {
+        Name: 'Dana Contact',
+        'Primary Email Address': 'Dana Contact <dana@example.com>',
+      },
+    ]
+
+    render(<ContactSearch contactData={complexContacts} addAdhocEmail={add} />)
+
+    const button = screen.getByText(/add to email list/i)
+    fireEvent.click(button)
+
+    expect(add).toHaveBeenCalledWith('dana@example.com', { switchToEmailTab: true })
   })
 })


### PR DESCRIPTION
## Summary
- have `addAdhocEmail` report explicit status codes so tab switching only happens after a successful addition
- let `ContactSearch` surface success and duplicate feedback while recalculating its height with layout-aware observers
- cover the new email-add path with an App-level test and adjust existing unit tests for the updated contract

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d45a3a14d08328b4c5178abcacc62b