### PR TITLE
Restyle interface with muted dark theme

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -212,12 +212,22 @@ const EmailGroups = ({
           <div className="empty-state">No groups match your search.</div>
         )}
 
-        {(selectedGroups.length > 0 || adhocEmails.length > 0) && (
-          <button onClick={clearAll} className="btn btn-secondary mt-0-5">
-            Clear All
-          </button>
-        )}
       </div>
+
+      {(selectedGroups.length > 0 || adhocEmails.length > 0 || hasRemovedEmails) && (
+        <div className="email-secondary-actions">
+          {(selectedGroups.length > 0 || adhocEmails.length > 0) && (
+            <button onClick={clearAll} className="btn btn-secondary">
+              Reset Selected Groups & Emails
+            </button>
+          )}
+          {hasRemovedEmails && (
+            <button onClick={restoreRemovedEmails} className="btn btn-ghost">
+              Restore Removed Emails
+            </button>
+          )}
+        </div>
+      )}
 
       {activeEmails.length > 0 && (
         <>
@@ -247,19 +257,9 @@ const EmailGroups = ({
             ))}
           </div>
           <p className="small-muted m-0">Tap an email to remove it from the list.</p>
-          {hasRemovedEmails && (
-            <button onClick={restoreRemovedEmails} className="btn btn-ghost">
-              Restore Removed Emails
-            </button>
-          )}
         </>
       )}
 
-      {hasRemovedEmails && activeEmails.length === 0 && (
-        <button onClick={restoreRemovedEmails} className="btn btn-ghost">
-          Restore Removed Emails
-        </button>
-      )}
     </div>
   )
 }

--- a/src/components/EmailGroups.test.jsx
+++ b/src/components/EmailGroups.test.jsx
@@ -52,7 +52,9 @@ describe('EmailGroups', () => {
     const groupA = screen.getByRole('button', { name: /Group A/i })
     await user.click(groupA)
     expect(screen.getByRole('button', { name: /Group A/i })).toHaveClass('is-selected')
-    const clear = screen.getByRole('button', { name: /Clear All/i })
+    const clear = screen.getByRole('button', {
+      name: /Reset Selected Groups & Emails/i,
+    })
     await user.click(clear)
     expect(screen.getByRole('button', { name: /Group A/i })).not.toHaveClass('is-selected')
   })

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,30 +1,30 @@
 :root {
-  --bg-primary: #031621;
-  --bg-secondary: rgba(6, 32, 44, 0.92);
-  --bg-elevated: rgba(7, 42, 55, 0.9);
-  --bg-panel: rgba(3, 24, 32, 0.88);
-  --surface-raised: rgba(6, 36, 46, 0.94);
-  --surface-hover: rgba(16, 76, 72, 0.97);
-  --text-light: #f3f8fb;
-  --text-muted: #9cc9d6;
-  --text-dark: #021218;
-  --accent: #00a779;
-  --accent-strong: #0b6fc6;
-  --accent-soft: rgba(11, 111, 198, 0.2);
-  --border-color: rgba(101, 172, 191, 0.5);
-  --button-text: #f9fbfd;
-  --button-bg: linear-gradient(135deg, #0b6fc6, #00a779);
-  --button-hover: linear-gradient(135deg, #0a5aa0, #009266);
-  --button-active: linear-gradient(135deg, #084778, #00704e);
-  --button-secondary: rgba(156, 201, 214, 0.18);
-  --button-secondary-hover: rgba(156, 201, 214, 0.3);
-  --button-secondary-active: rgba(156, 201, 214, 0.42);
-  --toast-success-bg: rgba(0, 167, 121, 0.32);
-  --toast-error-bg: rgba(244, 114, 114, 0.28);
-  --shadow-sm: 0 14px 28px rgba(3, 20, 28, 0.35);
-  --shadow-lg: 0 26px 48px rgba(3, 20, 28, 0.55);
-  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  --glow-accent: 0 0 0 1px rgba(11, 111, 198, 0.45);
+  --bg-primary: #090f16;
+  --bg-secondary: #111a25;
+  --bg-elevated: #151f2c;
+  --bg-panel: #0d141d;
+  --surface-raised: #1a2635;
+  --surface-hover: #223247;
+  --text-light: #f1f5f9;
+  --text-muted: #94a3b8;
+  --text-dark: #06090f;
+  --accent: #58c6b7;
+  --accent-strong: #3f83f8;
+  --accent-soft: rgba(88, 198, 183, 0.18);
+  --border-color: rgba(120, 150, 185, 0.32);
+  --button-text: #f8fafc;
+  --button-bg: linear-gradient(135deg, #3f83f8, #58c6b7);
+  --button-hover: linear-gradient(135deg, #326fce, #45b4a4);
+  --button-active: linear-gradient(135deg, #295ca8, #3a9c8e);
+  --button-secondary: rgba(148, 163, 184, 0.14);
+  --button-secondary-hover: rgba(148, 163, 184, 0.22);
+  --button-secondary-active: rgba(148, 163, 184, 0.32);
+  --toast-success-bg: rgba(88, 198, 183, 0.28);
+  --toast-error-bg: rgba(244, 114, 114, 0.22);
+  --shadow-sm: 0 10px 30px rgba(5, 12, 20, 0.35);
+  --shadow-lg: 0 24px 60px rgba(5, 12, 20, 0.55);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  --glow-accent: 0 0 0 1px rgba(63, 131, 248, 0.35);
   --app-shell-gap: clamp(1.5rem, 2vw, 2.5rem);
   --app-header-offset: 0px;
 }
@@ -37,9 +37,9 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(120% 160% at 20% 0%, rgba(11, 111, 198, 0.38), transparent 60%),
-    radial-gradient(120% 160% at 80% 100%, rgba(0, 167, 121, 0.32), transparent 65%),
-    linear-gradient(180deg, rgba(2, 18, 26, 0.9), rgba(3, 22, 30, 0.96));
+    radial-gradient(120% 180% at 18% 8%, rgba(63, 131, 248, 0.18), transparent 60%),
+    radial-gradient(120% 200% at 82% 96%, rgba(88, 198, 183, 0.16), transparent 70%),
+    linear-gradient(180deg, #070c12, #111924);
   color: var(--text-light);
   font-family: 'DM Sans', sans-serif;
   font-size: 18px;
@@ -77,10 +77,7 @@ body {
   gap: clamp(1rem, 1.6vw, 1.75rem);
   padding: clamp(1.5rem, 2vw, 2.4rem);
   border-radius: 28px;
-  background:
-    radial-gradient(140% 120% at 0% 0%, rgba(11, 111, 198, 0.22), transparent 55%),
-    radial-gradient(140% 140% at 100% 100%, rgba(0, 167, 121, 0.18), transparent 55%),
-    rgba(3, 24, 32, 0.88);
+  background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   box-shadow: var(--shadow-lg);
   backdrop-filter: blur(26px);
@@ -92,9 +89,8 @@ body {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(135deg, rgba(11, 111, 198, 0.18), rgba(0, 167, 121, 0.14));
-  mix-blend-mode: screen;
-  opacity: 0.75;
+  background: linear-gradient(135deg, rgba(63, 131, 248, 0.08), rgba(88, 198, 183, 0.06));
+  opacity: 0.5;
 }
 
 .app-identity {
@@ -113,9 +109,9 @@ body {
   justify-content: center;
   padding: clamp(1rem, 1.7vw, 1.85rem);
   border-radius: 22px;
-  background: rgba(2, 20, 28, 0.8);
-  border: 1px solid rgba(101, 172, 191, 0.45);
-  box-shadow: 0 24px 42px rgba(3, 20, 28, 0.45);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 36px rgba(6, 12, 20, 0.45);
   overflow: hidden;
   min-height: clamp(140px, 18vw, 200px);
 }
@@ -124,10 +120,8 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background:
-    radial-gradient(120% 90% at 10% 15%, rgba(11, 111, 198, 0.28), transparent 60%),
-    radial-gradient(110% 140% at 90% 85%, rgba(0, 167, 121, 0.24), transparent 60%);
-  opacity: 0.9;
+  background: radial-gradient(120% 90% at 10% 15%, rgba(63, 131, 248, 0.15), transparent 60%);
+  opacity: 0.7;
   pointer-events: none;
 }
 
@@ -135,7 +129,7 @@ body {
   width: clamp(160px, 21vw, 240px);
   max-width: 100%;
   height: auto;
-  filter: drop-shadow(0 14px 32px rgba(11, 111, 198, 0.35));
+  filter: drop-shadow(0 14px 28px rgba(17, 27, 38, 0.55));
   position: relative;
   z-index: 1;
 }
@@ -147,9 +141,9 @@ body {
   justify-content: center;
   padding: 0.85rem 1.4rem;
   border-radius: 18px;
-  border: 1px solid rgba(101, 172, 191, 0.55);
-  background: linear-gradient(135deg, rgba(11, 111, 198, 0.55), rgba(0, 167, 121, 0.48));
-  box-shadow: 0 22px 44px rgba(11, 111, 198, 0.3);
+  border: 1px solid var(--border-color);
+  background: linear-gradient(135deg, rgba(63, 131, 248, 0.32), rgba(88, 198, 183, 0.28));
+  box-shadow: 0 18px 36px rgba(17, 27, 38, 0.5);
   font-weight: 700;
   letter-spacing: 0.36rem;
   text-transform: uppercase;
@@ -175,10 +169,9 @@ body {
   justify-content: center;
   padding: clamp(1.15rem, 1.8vw, 1.6rem);
   border-radius: 22px;
-  background:
-    linear-gradient(160deg, rgba(2, 22, 30, 0.92), rgba(8, 44, 58, 0.88));
-  border: 1px solid rgba(101, 172, 191, 0.45);
-  box-shadow: 0 20px 38px rgba(3, 20, 28, 0.5);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 38px rgba(6, 12, 20, 0.45);
 }
 
 .app-meta-card > * {
@@ -207,9 +200,9 @@ body {
   gap: 0.75rem 1rem;
   padding: 0.6rem 0.85rem;
   border-radius: 999px;
-  background: rgba(3, 24, 32, 0.72);
-  border: 1px solid rgba(101, 172, 191, 0.4);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background: rgba(21, 33, 45, 0.75);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-inset);
 }
 
 .app-toolbar-meta {
@@ -235,13 +228,10 @@ body {
 .module-card {
   --module-pad: clamp(1.25rem, 2vw, 2.35rem);
   width: min(100%, 1120px);
-  background:
-    radial-gradient(120% 120% at 0% 0%, rgba(11, 111, 198, 0.14), transparent 55%),
-    radial-gradient(140% 160% at 100% 100%, rgba(0, 167, 121, 0.14), transparent 60%),
-    var(--bg-secondary);
-  backdrop-filter: blur(20px);
+  background: var(--bg-secondary);
+  backdrop-filter: blur(18px);
   border-radius: 26px;
-  border: 1px solid rgba(101, 172, 191, 0.38);
+  border: 1px solid var(--border-color);
   box-shadow: var(--shadow-lg);
   padding: var(--module-pad);
   display: flex;
@@ -274,10 +264,10 @@ body {
   top: calc(var(--module-pad) * -1 + clamp(0.5rem, 1.2vw, 1.25rem));
   margin: calc(var(--module-pad) * -1) calc(var(--module-pad) * -1) 1.25rem;
   padding: clamp(1rem, 1.5vw, 1.5rem) var(--module-pad);
-  background: rgba(4, 24, 30, 0.92);
-  border-bottom: 1px solid rgba(101, 172, 191, 0.4);
+  background: rgba(17, 27, 38, 0.82);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 24px 24px 20px 20px;
-  box-shadow: 0 22px 32px rgba(1, 10, 12, 0.45);
+  box-shadow: 0 16px 32px rgba(5, 12, 20, 0.45);
   backdrop-filter: blur(22px);
   z-index: 6;
 }
@@ -314,38 +304,38 @@ body {
 }
 
 .btn.btn-secondary {
-  background: var(--button-secondary);
+  background: rgba(63, 131, 248, 0.12);
   color: var(--text-light);
-  border: 1px solid rgba(156, 201, 214, 0.4);
+  border: 1px solid var(--border-color);
   box-shadow: none;
 }
 
 .btn.btn-secondary:hover {
-  background: var(--button-secondary-hover);
+  background: rgba(63, 131, 248, 0.18);
   box-shadow: var(--shadow-sm);
 }
 
 .btn.btn-secondary:active,
 .btn.btn-secondary.active {
-  background: var(--button-secondary-active);
+  background: rgba(63, 131, 248, 0.24);
 }
 
 .btn.btn-ghost {
-  background: rgba(11, 111, 198, 0.18);
-  border: 1px solid rgba(11, 111, 198, 0.32);
-  box-shadow: 0 12px 24px rgba(3, 20, 28, 0.32);
+  background: rgba(88, 198, 183, 0.14);
+  border: 1px solid rgba(88, 198, 183, 0.32);
+  box-shadow: 0 12px 24px rgba(8, 16, 24, 0.32);
   color: var(--text-light);
 }
 
 .btn.btn-ghost:hover {
-  background: rgba(11, 111, 198, 0.26);
-  border-color: rgba(11, 111, 198, 0.45);
+  background: rgba(88, 198, 183, 0.22);
+  border-color: rgba(88, 198, 183, 0.42);
   box-shadow: var(--shadow-sm);
 }
 
 .btn.btn-ghost:active,
 .btn.btn-ghost.active {
-  background: rgba(11, 111, 198, 0.32);
+  background: rgba(88, 198, 183, 0.28);
   box-shadow: none;
 }
 
@@ -417,24 +407,30 @@ body {
 
 
 .tab-selector {
-  display: inline-flex;
-  gap: 0.75rem;
-  border: 1px solid rgba(101, 172, 191, 0.55);
-  padding: 0.35rem 0.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.45rem;
   border-radius: 999px;
-  background: rgba(3, 24, 32, 0.78);
-  box-shadow: 0 20px 36px rgba(3, 20, 28, 0.48);
+  background: rgba(17, 27, 38, 0.78);
+  box-shadow: var(--shadow-sm);
   align-self: flex-start;
 }
 
 .tab-button {
   cursor: pointer;
-  padding: 0.45rem 1.4rem;
+  padding: 0.5rem 1.25rem;
   border: none;
   background: transparent;
   border-radius: 999px;
   color: var(--text-muted);
   font-weight: 600;
+  letter-spacing: 0.01em;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -443,9 +439,9 @@ body {
 }
 
 .tab-button.active {
-  background: linear-gradient(135deg, rgba(0, 167, 121, 0.36), rgba(11, 111, 198, 0.4));
+  background: linear-gradient(135deg, rgba(63, 131, 248, 0.24), rgba(88, 198, 183, 0.24));
   color: var(--text-light);
-  box-shadow: 0 14px 28px rgba(11, 111, 198, 0.4);
+  box-shadow: 0 12px 28px rgba(12, 22, 32, 0.45);
 }
 
 .text-center { text-align: center; }
@@ -510,6 +506,17 @@ body {
   }
 }
 
+@media (max-width: 640px) {
+  .tab-selector {
+    width: 100%;
+  }
+
+  .tab-button {
+    flex: 1 1 calc(50% - 0.5rem);
+    text-align: center;
+  }
+}
+
 @media (max-width: 450px) {
   .stack-on-small {
     flex-direction: column;
@@ -518,13 +525,13 @@ body {
 
   .tab-selector {
     align-self: stretch;
-    justify-content: space-between;
-    flex-wrap: wrap;
+    justify-content: stretch;
     width: 100%;
+    gap: 0.4rem;
   }
 
   .tab-button {
-    flex: 1 1 45%;
+    flex: 1 1 100%;
     text-align: center;
   }
 }
@@ -555,7 +562,7 @@ a[href^="mailto:"]:hover {
 }
 
 *::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(0, 167, 121, 0.4), rgba(0, 113, 206, 0.45));
+  background: linear-gradient(180deg, rgba(63, 131, 248, 0.35), rgba(88, 198, 183, 0.35));
   border-radius: 999px;
 }
 
@@ -574,7 +581,7 @@ a[href^="mailto:"]:hover {
 }
 
 .minimal-scrollbar::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(0, 167, 121, 0.4), rgba(0, 113, 206, 0.45));
+  background: linear-gradient(180deg, rgba(63, 131, 248, 0.35), rgba(88, 198, 183, 0.35));
   border-radius: 999px;
 }
 
@@ -688,11 +695,8 @@ a[href^="mailto:"]:hover {
   position: relative;
   flex: 1;
   border-radius: 20px;
-  border: 1px solid rgba(101, 172, 191, 0.45);
-  background:
-    radial-gradient(120% 140% at 20% 0%, rgba(11, 111, 198, 0.16), transparent 60%),
-    radial-gradient(120% 160% at 80% 100%, rgba(0, 167, 121, 0.16), transparent 60%),
-    linear-gradient(145deg, rgba(4, 20, 24, 0.92), rgba(6, 27, 33, 0.82));
+  border: 1px solid var(--border-color);
+  background: var(--surface-raised);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
 }
@@ -710,21 +714,16 @@ a[href^="mailto:"]:hover {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background:
-    radial-gradient(120% 140% at 20% 0%, rgba(11, 111, 198, 0.2), transparent 55%),
-    radial-gradient(120% 160% at 80% 100%, rgba(0, 167, 121, 0.2), transparent 60%),
-    linear-gradient(180deg, rgba(4, 20, 24, 0.28), rgba(4, 20, 24, 0.6));
-  mix-blend-mode: soft-light;
+  background: linear-gradient(180deg, rgba(7, 13, 22, 0.35), rgba(7, 13, 22, 0.65));
+  mix-blend-mode: normal;
   backdrop-filter: saturate(1.05);
 }
 
 .radar-fallback {
   padding: 2rem;
   border-radius: 20px;
-  background:
-    radial-gradient(120% 140% at 0% 0%, rgba(11, 111, 198, 0.12), transparent 60%),
-    rgba(4, 20, 24, 0.9);
-  border: 1px solid rgba(101, 172, 191, 0.4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-color);
   box-shadow: var(--shadow-sm);
 }
 
@@ -740,12 +739,9 @@ a[href^="mailto:"]:hover {
 
 .contact-card {
   position: relative;
-  background:
-    radial-gradient(120% 140% at 0% 0%, rgba(11, 111, 198, 0.16), transparent 60%),
-    radial-gradient(120% 160% at 100% 100%, rgba(0, 167, 121, 0.16), transparent 60%),
-    var(--surface-raised);
+  background: var(--surface-raised);
   border-radius: 22px;
-  border: 1px solid rgba(101, 172, 191, 0.4);
+  border: 1px solid var(--border-color);
   color: var(--text-light);
   transition: transform 0.25s ease, box-shadow 0.25s ease, border 0.25s ease;
   animation: fade-in 0.3s ease;
@@ -764,7 +760,7 @@ a[href^="mailto:"]:hover {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: radial-gradient(circle at top, rgba(0, 167, 121, 0.18), transparent 60%);
+  background: radial-gradient(circle at top, rgba(63, 131, 248, 0.14), transparent 65%);
   opacity: 0;
   transition: opacity 0.25s ease;
   pointer-events: none;
@@ -774,7 +770,7 @@ a[href^="mailto:"]:hover {
 .contact-card:hover {
   transform: translateY(-4px);
   box-shadow: var(--shadow-lg);
-  border-color: rgba(11, 111, 198, 0.5);
+  border-color: rgba(120, 150, 185, 0.5);
 }
 
 .contact-card:hover::before {
@@ -791,7 +787,7 @@ a[href^="mailto:"]:hover {
   width: 48px;
   height: 48px;
   border-radius: 16px;
-  background: rgba(0, 167, 121, 0.32);
+  background: rgba(63, 131, 248, 0.18);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -837,11 +833,9 @@ a[href^="mailto:"]:hover {
 .list-surface {
   width: min(100%, 880px);
   margin: 0 auto;
-  background:
-    radial-gradient(120% 120% at 0% 0%, rgba(11, 111, 198, 0.12), transparent 55%),
-    rgba(3, 24, 32, 0.78);
+  background: var(--bg-elevated);
   border-radius: 20px;
-  border: 1px solid rgba(101, 172, 191, 0.38);
+  border: 1px solid var(--border-color);
   padding: 1rem;
   box-shadow: var(--shadow-sm);
   max-height: min(420px, 60vh);
@@ -856,9 +850,8 @@ a[href^="mailto:"]:hover {
 
 .list-item-button {
   border-radius: 16px;
-  border: 1px solid rgba(101, 172, 191, 0.25);
-  background:
-    linear-gradient(160deg, rgba(3, 24, 32, 0.9), rgba(4, 28, 36, 0.78));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: var(--bg-panel);
   color: var(--text-light);
   padding: 0.6rem 1.1rem;
   display: inline-flex;
@@ -883,13 +876,13 @@ a[href^="mailto:"]:hover {
 .list-item-button:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-sm);
-  border-color: rgba(11, 111, 198, 0.35);
-  background: rgba(4, 30, 38, 0.95);
+  border-color: rgba(120, 150, 185, 0.45);
+  background: var(--surface-hover);
 }
 
 .list-item-button.is-selected {
-  background: linear-gradient(135deg, rgba(0, 167, 121, 0.42), rgba(11, 111, 198, 0.46));
-  border-color: rgba(11, 111, 198, 0.6);
+  background: linear-gradient(135deg, rgba(63, 131, 248, 0.22), rgba(88, 198, 183, 0.22));
+  border-color: rgba(88, 198, 183, 0.45);
   box-shadow: var(--shadow-lg);
 }
 
@@ -909,15 +902,13 @@ a[href^="mailto:"]:hover {
   overflow-y: auto;
   padding: 0.5rem;
   border-radius: 16px;
-  background:
-    radial-gradient(120% 120% at 0% 0%, rgba(11, 111, 198, 0.1), transparent 60%),
-    rgba(3, 24, 32, 0.82);
-  border: 1px solid rgba(101, 172, 191, 0.38);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-color);
 }
 
 .email-chip {
-  border: 1px solid rgba(11, 111, 198, 0.5);
-  background: linear-gradient(135deg, rgba(11, 111, 198, 0.24), rgba(0, 167, 121, 0.24));
+  border: 1px solid rgba(88, 198, 183, 0.42);
+  background: linear-gradient(135deg, rgba(63, 131, 248, 0.22), rgba(88, 198, 183, 0.22));
   color: var(--text-light);
   padding: 0.45rem 0.85rem;
   border-radius: 999px;
@@ -931,12 +922,12 @@ a[href^="mailto:"]:hover {
 
 .email-chip:hover {
   transform: translateY(-1px);
-  border-color: rgba(11, 111, 198, 0.75);
-  background: linear-gradient(135deg, rgba(11, 111, 198, 0.3), rgba(0, 167, 121, 0.3));
+  border-color: rgba(88, 198, 183, 0.58);
+  background: linear-gradient(135deg, rgba(63, 131, 248, 0.28), rgba(88, 198, 183, 0.28));
 }
 
 .email-chip:focus-visible {
-  outline: 2px solid rgba(11, 111, 198, 0.85);
+  outline: 2px solid rgba(63, 131, 248, 0.75);
   outline-offset: 2px;
 }
 
@@ -966,6 +957,18 @@ a[href^="mailto:"]:hover {
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+}
+
+.email-secondary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  margin: 1rem 0;
+}
+
+.email-secondary-actions .btn {
+  flex: 0 0 auto;
 }
 
 .copied-indicator {


### PR DESCRIPTION
## Summary
- refresh the global dark palette with muted gradients and updated component surfaces for a calmer modern look
- update tab selector styling/responsiveness and soften list, chip, and radar panels to match the new theme
- relocate the reset and restore controls outside the group grid and rename the reset action for clarity, adjusting tests accordingly

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d475ababc883289d537b712a571126