### PR TITLE
Improve header layout and button styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,79 +105,63 @@ function App() {
   };
 
   return (
-    <div className="fade-in" style={{ fontFamily: 'DM Sans, sans-serif', background: 'var(--bg-primary)', color: 'var(--text-light)', minHeight: '100vh', padding: '2rem' }}>
+    <div className="app-shell fade-in">
       <Toaster position="top-right" toastOptions={toastOptions} />
-      <div style={{ position: 'fixed', top: '1rem', right: '1rem', background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '0.5rem 1rem', textAlign: 'center', fontSize: '0.9rem' }}>
-        <div style={{ fontSize: '1.6rem', fontWeight: 'bold' }}>Code: {currentCode}</div>
-        <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Prev: {previousCode || 'N/A'}</div>
+      <div className="code-widget">
+        <div className="code-widget__current">Code: {currentCode}</div>
+        <div className="code-widget__previous">Prev: {previousCode || 'N/A'}</div>
         <div className="progress-container">
           <div key={progressKey} className="progress-bar" />
         </div>
       </div>
-      {logoAvailable ? (
-        <img src="logo.png" alt="NOC List Logo" style={{ width: '200px', marginBottom: '1rem' }} />
-      ) : (
-        <pre style={{
-          fontFamily: 'monospace',
-          fontSize: '1rem',
-          marginBottom: '1rem',
-          lineHeight: '1.2',
-        }}>
-          {`    _   ______  ______   __    _      __
+      <header className="app-header">
+        {logoAvailable ? (
+          <img src="logo.png" alt="NOC List Logo" className="app-logo" />
+        ) : (
+          <pre
+            style={{
+              fontFamily: 'monospace',
+              fontSize: '1rem',
+              margin: 0,
+              lineHeight: '1.2',
+            }}
+          >
+            {`    _   ______  ______   __    _      __
    / | / / __ \/ ____/  / /   (_)____/ /_
   /  |/ / / / / /      / /   / / ___/ __/
  / /|  / /_/ / /___   / /___/ (__  ) /_
 /_/ |_|\____/\____/  /_____/_/____/\__/`}
-        </pre>
-      )}
-      <div style={{ fontFamily: 'DM Sans, sans-serif', display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-      <div
-        className="stack-on-small"
-        style={{
-      gap: '2rem',
-      borderBottom: '1px solid var(--border-color)',
-      paddingBottom: '0.5rem',
-      marginBottom: '1.5rem',
-      fontSize: '1.05rem'
-    }}>
-      <div
-        onClick={() => setTab('email')}
-        style={{
-          cursor: 'pointer',
-          paddingBottom: '0.25rem',
-          borderBottom: tab === 'email' ? '3px solid var(--accent)' : '3px solid transparent',
-          color: tab === 'email' ? 'var(--text-light)' : 'var(--text-muted)',
-          fontWeight: tab === 'email' ? 'bold' : 'normal'
-        }}
-      >
-        Email Groups
-      </div>
-      <div
-        onClick={() => setTab('contact')}
-        style={{
-          cursor: 'pointer',
-          paddingBottom: '0.25rem',
-          borderBottom: tab === 'contact' ? '3px solid var(--accent)' : '3px solid transparent',
-          color: tab === 'contact' ? 'var(--text-light)' : 'var(--text-muted)',
-          fontWeight: tab === 'contact' ? 'bold' : 'normal'
-        }}
-      >
-        Contact Search
-      </div>
-    </div>
-      </div>
+          </pre>
+        )}
+        <p className="header-note">Pick a tab and follow the simple steps to build your email list.</p>
+      </header>
 
-      <div
-        className="stack-on-small"
-        style={{ fontFamily: 'DM Sans, sans-serif', gap: '1rem', marginBottom: '1rem' }}>
+      <nav className="tab-strip stack-on-small">
+        <button
+          type="button"
+          onClick={() => setTab('email')}
+          className={`tab-button ${tab === 'email' ? 'active' : ''}`}
+        >
+          Email Groups
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('contact')}
+          className={`tab-button ${tab === 'contact' ? 'active' : ''}`}
+        >
+          Contact Search
+        </button>
+      </nav>
 
-<button
+      <div className="refresh-row stack-on-small">
+        <button
           onClick={refreshData}
-          className="btn"
+          className="btn btn-secondary"
         >
           Refresh Data
         </button>
-        <span style={{ alignSelf: 'center', fontSize: '0.9rem' }}>Last Refreshed: {lastRefresh}</span>
+        <span className="refresh-note">Last refreshed: {lastRefresh}</span>
+        <span className="refresh-hint">Tap refresh if the sheets change.</span>
       </div>
 
       {tab === 'email' ? (

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -39,6 +39,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
           Open Contact List Excel
         </button>
       </div>
+      <p className="helper-text">Type a name or word to find the right person.</p>
       <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
         <div style={{ position: 'relative', flex: '1 1 250px', minWidth: 0, maxWidth: '300px' }}>
           <input

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -70,6 +70,8 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
         </button>
       </div>
 
+      <p className="helper-text">Click a group to add everyone inside it.</p>
+
       <div className="stack-on-small" style={{ alignItems: 'center', marginBottom: '1.5rem', gap: '0.75rem' }}>
         <div style={{ position: 'relative', flex: '1 1 250px', maxWidth: '300px' }}>
           <input
@@ -120,16 +122,16 @@ const EmailGroups = ({ emailData, adhocEmails, selectedGroups, setSelectedGroups
 
       {mergedEmails.length > 0 && (
         <>
-          <div style={{ marginBottom: '0.5rem', display: 'flex', gap: '0.75rem' }}>
-            <button onClick={copyToClipboard} className="btn fade-in">
+          <div style={{ marginBottom: '0.5rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <button onClick={copyToClipboard} className="btn btn-quiet fade-in">
               Copy Email List
             </button>
-            <button onClick={launchTeams} className="btn btn-secondary fade-in">
+            <button onClick={launchTeams} className="btn btn-important fade-in">
               Start Teams Meeting
             </button>
             {copied && <span style={{ color: 'lightgreen', alignSelf: 'center' }}>Copied</span>}
           </div>
-          <div style={{ background: 'var(--bg-secondary)', padding: '1rem', borderRadius: 'var(--radius)', color: 'var(--text-light)' }}>
+          <div className="info-card">
             <strong>Merged Emails:</strong>
             <div style={{ wordBreak: 'break-word', marginTop: '0.5rem' }}>
               {mergedEmails.join(', ')}

--- a/src/theme.css
+++ b/src/theme.css
@@ -11,6 +11,9 @@
   --button-secondary-hover: #666666;
   --button-active: #777777;
   --button-text: #ffffff;
+  --button-important: #7f62ff;
+  --button-important-hover: #8d72ff;
+  --button-important-shadow: rgba(127, 98, 255, 0.45);
   --toast-success-bg: var(--button-bg);
   --toast-error-bg: #555555;
   --border-color: #444444;
@@ -68,6 +71,33 @@ body {
 .btn-secondary.active {
   background: var(--button-active);
   color: var(--button-text);
+}
+
+.btn-quiet {
+  background: var(--button-bg);
+  border: 1px solid var(--border-color);
+}
+
+.btn-quiet:hover {
+  background: var(--button-hover);
+  border-color: var(--button-secondary-hover);
+}
+
+.btn-important {
+  background: var(--button-important);
+  color: var(--text-light);
+  box-shadow: 0 0 16px var(--button-important-shadow);
+}
+
+.btn-important:hover {
+  background: var(--button-important-hover);
+  box-shadow: 0 0 18px var(--button-important-shadow);
+}
+
+.btn-important:active,
+.btn-important.active {
+  background: var(--button-active);
+  box-shadow: none;
 }
 
 .input {
@@ -186,6 +216,121 @@ body::-webkit-scrollbar-track {
 body::-webkit-scrollbar-thumb {
   background-color: var(--accent);
   border-radius: var(--radius);
+}
+
+.app-shell {
+  font-family: 'DM Sans', sans-serif;
+  background: var(--bg-primary);
+  color: var(--text-light);
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.app-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 560px;
+}
+
+.app-logo {
+  width: 260px;
+  max-width: 100%;
+}
+
+.header-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.code-widget {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.code-widget__current {
+  font-size: 1.6rem;
+  font-weight: bold;
+}
+
+.code-widget__previous {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.tab-strip {
+  display: flex;
+  gap: 2rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.tab-button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font: inherit;
+  cursor: pointer;
+  padding: 0 0 0.25rem;
+  border-bottom: 3px solid transparent;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+  color: var(--text-light);
+}
+
+.tab-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tab-button.active {
+  color: var(--text-light);
+  border-bottom-color: var(--accent);
+  font-weight: 700;
+}
+
+.refresh-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.refresh-note {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.refresh-hint {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.helper-text {
+  margin: 0 0 0.75rem 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.info-card {
+  background: var(--bg-secondary);
+  padding: 1rem;
+  border-radius: var(--radius);
+  color: var(--text-light);
 }
 
 /* Progress bar for code timer */


### PR DESCRIPTION
## Summary
- reorganize the header so tabs and refresh controls always follow it and enlarge the logo
- add short helper descriptions for email groups and contacts to guide younger users
- adjust button styling so copy matches default state and the Teams button stands out slightly

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d48e7c64d48328bc76b08fa9aa1659