### PR TITLE
Reduce packaged app footprint

### DIFF
--- a/.electronignore
+++ b/.electronignore
@@ -1,0 +1,12 @@
+# Exclude development-only sources and tooling from the packaged app
+/dist/dev
+/node_modules/.cache
+/release
+/src
+/public
+/start-app.js
+/vite.config.js
+/vitest.config.js
+*.test.js
+*.md
+logo.txt

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true"
   },
   "dependencies": {
     "chokidar": "^3.6.0",


### PR DESCRIPTION
## Summary
- add an `.electronignore` file to drop development assets from the packaged bundle
- enable asar archiving and pruning when creating the Windows package to shrink the release contents

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d4928323308328af8e66b83555136d