### PR TITLE
Tighten header layout and enlarge logo

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -68,7 +68,7 @@ body {
 
 .app-header-card {
   position: relative;
-  padding: clamp(0.95rem, 1.1vw + 0.65rem, 1.5rem);
+  padding: clamp(0.75rem, 0.9vw + 0.5rem, 1.15rem);
   border-radius: 18px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
@@ -82,9 +82,10 @@ body {
 
 .app-header-row {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: clamp(1rem, 1.3vw, 1.65rem);
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.75rem, 1vw, 1.25rem);
   width: 100%;
 }
 
@@ -92,8 +93,8 @@ body {
   flex: 1 1 360px;
   display: flex;
   align-items: center;
-  gap: clamp(0.75rem, 1vw, 1.1rem);
-  padding: clamp(0.65rem, 0.9vw, 0.95rem) clamp(0.8rem, 1.2vw, 1.1rem);
+  gap: clamp(0.6rem, 0.85vw, 0.95rem);
+  padding: clamp(0.55rem, 0.8vw, 0.9rem) clamp(0.7rem, 1vw, 1rem);
   border-radius: 14px;
   border: 1px solid rgba(110, 142, 184, 0.45);
   background: rgba(12, 19, 29, 0.72);
@@ -105,15 +106,15 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.3rem 0.55rem;
+  padding: 0.25rem 0.5rem;
   border-radius: 10px;
   border: 1px solid rgba(110, 142, 184, 0.25);
   background: rgba(16, 24, 35, 0.75);
-  min-width: clamp(96px, 12vw, 148px);
+  min-width: clamp(110px, 13vw, 180px);
 }
 
 .app-logo {
-  width: clamp(120px, 16vw, 188px);
+  width: clamp(150px, 18vw, 220px);
   max-width: 100%;
   height: auto;
 }
@@ -170,15 +171,28 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   gap: clamp(0.55rem, 0.9vw, 0.85rem);
   min-width: 0;
-  width: 100%;
+  flex: 1 1 320px;
+  width: auto;
 }
 
 .app-header-controls .tab-selector {
   flex: 0 0 auto;
   margin-right: auto;
+}
+
+@media (max-width: 900px) {
+  .app-header-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app-header-controls {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }
 
 .app-toolbar {


### PR DESCRIPTION
## Summary
- reduce header card padding and switch header row to a tighter flex row layout for a more compact shell
- tweak identity card spacing while letting the controls share the row to reclaim vertical space
- enlarge the logo clamp size and ensure responsive fallback to a stacked layout on narrow screens

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d499c60a08832885dc6e06363c6ac3