### PR TITLE
Fix header spacing responsiveness

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -84,7 +84,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: clamp(0.75rem, 1vw, 1.25rem);
   width: 100%;
 }
@@ -176,11 +176,11 @@ body {
   min-width: 0;
   flex: 1 1 320px;
   width: auto;
+  margin-left: auto;
 }
 
 .app-header-controls .tab-selector {
   flex: 0 0 auto;
-  margin-right: auto;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- prevent the header row from distributing children with large empty space as the viewport narrows
- adjust header control alignment so tab buttons stay beside the refresh toolbar without overlapping the logo block

## Testing
- `npm test -- --run` *(fails: missing @testing-library/user-event dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d49f12da888328a8c9ab59b599938a