### PR TITLE
Keep header toolbar footprint when radar tab active

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -204,14 +204,19 @@ function App() {
             <div className="app-header-controls">
               <TabSelector tab={tab} setTab={setTab} />
 
-              {tab !== 'radar' && (
-                <div className="app-toolbar">
-                  <button onClick={refreshData} className="btn btn-ghost">
-                    Refresh
-                  </button>
-                  <span className="app-toolbar-meta">Updated {lastRefresh}</span>
-                </div>
-              )}
+              <div
+                className={`app-toolbar${tab === 'radar' ? ' app-toolbar--hidden' : ''}`}
+                aria-hidden={tab === 'radar'}
+              >
+                <button
+                  onClick={refreshData}
+                  className="btn btn-ghost"
+                  tabIndex={tab === 'radar' ? -1 : undefined}
+                >
+                  Refresh
+                </button>
+                <span className="app-toolbar-meta">Updated {lastRefresh}</span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/theme.css
+++ b/src/theme.css
@@ -85,6 +85,7 @@ body {
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
+  align-content: flex-start;
   gap: clamp(0.75rem, 1vw, 1.25rem);
   width: 100%;
 }
@@ -187,11 +188,15 @@ body {
   .app-header-row {
     flex-direction: column;
     align-items: stretch;
+    gap: clamp(0.5rem, 1.4vw, 0.85rem);
   }
 
   .app-header-controls {
     width: 100%;
     justify-content: flex-start;
+    margin-left: 0;
+    row-gap: 0.5rem;
+    align-items: flex-start;
   }
 }
 
@@ -203,6 +208,11 @@ body {
   min-width: 0;
   font-size: 0.82rem;
   margin-left: auto;
+}
+
+.app-toolbar--hidden {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .app-toolbar-meta {


### PR DESCRIPTION
## Summary
- keep the header toolbar mounted and visually hide it on the radar tab to preserve tab selector positioning
- add a hidden toolbar style that removes interactivity while retaining layout space

## Testing
- npm test *(fails: vitest cannot resolve @testing-library/user-event)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a3ec7f1083289a57065cae85f60f