### PR TITLE
Improve header responsiveness

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -81,11 +81,9 @@ body {
 
 
 .app-header-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-start;
-  align-content: flex-start;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 1fr);
+  align-items: stretch;
   gap: clamp(0.75rem, 1vw, 1.25rem);
   width: 100%;
 }
@@ -172,31 +170,27 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: clamp(0.55rem, 0.9vw, 0.85rem);
   min-width: 0;
-  flex: 1 1 320px;
-  width: auto;
-  margin-left: auto;
+  width: 100%;
 }
 
 .app-header-controls .tab-selector {
-  flex: 0 0 auto;
+  flex: 1 1 260px;
+  min-width: min(100%, 320px);
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1180px) {
   .app-header-row {
-    flex-direction: column;
-    align-items: stretch;
-    gap: clamp(0.5rem, 1.4vw, 0.85rem);
+    grid-template-columns: 1fr;
+    gap: clamp(0.6rem, 1.2vw, 1rem);
   }
 
   .app-header-controls {
-    width: 100%;
     justify-content: flex-start;
-    margin-left: 0;
-    row-gap: 0.5rem;
     align-items: flex-start;
+    row-gap: 0.5rem;
   }
 }
 
@@ -656,6 +650,9 @@ body {
 @media (max-width: 900px) {
   .identity-card {
     flex: 1 1 100%;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
   }
 
   .identity-card__content {
@@ -670,6 +667,7 @@ body {
   .app-header-controls {
     justify-content: flex-start;
     width: 100%;
+    margin-left: 0;
   }
 
   .app-header-controls .tab-selector {
@@ -688,6 +686,28 @@ body {
 }
 
 @media (max-width: 640px) {
+  .identity-card {
+    text-align: center;
+    align-items: center;
+  }
+
+  .identity-card__content {
+    width: 100%;
+    align-items: center;
+  }
+
+  .identity-card__clock,
+  .identity-card__code {
+    width: 100%;
+    align-items: center;
+    text-align: center;
+  }
+
+  .identity-card__clock > *,
+  .identity-card__code > * {
+    width: 100%;
+  }
+
   .tab-selector {
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- refactor the header container to use a two-column grid that collapses earlier for narrow viewports
- let the tab selector grow and wrap with the toolbar while adding small-screen tweaks for the identity card content

## Testing
- `npm test` *(fails: missing @testing-library/user-event dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a97badac8328b19c0a9ec025a337