### PR TITLE
Switch app typography to Barlow

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <title>NOC List</title>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,7 +147,7 @@ function App() {
         border: '1px solid var(--border-color)',
         fontSize: '0.9rem',
         borderRadius: '6px',
-        fontFamily: 'DM Sans, sans-serif',
+        fontFamily: 'Barlow, DM Sans, sans-serif',
       },
       success: {
         icon: '✓',

--- a/src/theme.css
+++ b/src/theme.css
@@ -37,7 +37,7 @@ body {
   min-height: 100vh;
   background: linear-gradient(180deg, #04070d 0%, #0a111a 100%);
   color: var(--text-light);
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Barlow', 'DM Sans', sans-serif;
   font-size: 18px;
   -webkit-font-smoothing: antialiased;
   color-scheme: dark;
@@ -293,7 +293,7 @@ body {
   cursor: pointer;
   font-weight: 600;
   font-size: 0.92rem;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Barlow', 'DM Sans', sans-serif;
   letter-spacing: 0.01em;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
     box-shadow 0.2s ease;


### PR DESCRIPTION
## Summary
- load the Barlow family from Google Fonts and make it the primary UI typeface
- update global styles and toast configuration to use Barlow with DM Sans as fallback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b648fccc8328adaa11eb5b417761