### PR TITLE
Improve header spacing and integrate clock

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -192,9 +192,10 @@ function App() {
                     previousCode={previousCode}
                     progressKey={progressKey}
                     intervalMs={intervalMs}
-                  />
+                  >
+                    <Clock />
+                  </CodeDisplay>
                 </div>
-                <Clock />
               </div>
             </div>
 

--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -9,7 +9,7 @@ import React, { useEffect, useRef, useState } from 'react'
  * @param {number} props.progressKey - Forces animation restart when code updates.
  * @param {number} props.intervalMs - Duration of code validity in ms.
  */
-const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => {
+const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs, children }) => {
   const [progress, setProgress] = useState(0)
 
   const rafRef = useRef()
@@ -36,11 +36,14 @@ const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs }) => 
 
   return (
     <div className="code-display">
-      <div className="code-display__meta">
-        <span className="small-text text-muted">Current Code</span>
-        {hasPrevious && <span className="small-muted">Prev: {previousCode}</span>}
+      <div className="code-display__header">
+        <div className="code-display__meta">
+          <span className="small-text text-muted">Current Code</span>
+          {hasPrevious && <span className="code-display__previous small-muted">Prev: {previousCode}</span>}
+        </div>
+        {children && <div className="code-display__aside">{children}</div>}
       </div>
-      <div className="large-bold" aria-live="polite">
+      <div className="code-display__code large-bold" aria-live="polite">
         {currentCode}
       </div>
       <div

--- a/src/theme.css
+++ b/src/theme.css
@@ -161,12 +161,16 @@ body {
 .clock {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.15rem;
+  align-items: flex-end;
+  gap: 0.2rem;
   line-height: 1.2;
+  text-align: right;
+  min-width: 0;
 }
 
 .clock__time {
+  font-size: 1.1rem;
+  font-weight: 600;
   letter-spacing: 0.04em;
 }
 
@@ -234,7 +238,7 @@ body {
   overscroll-behavior-y: contain;
   padding-bottom: 2rem;
   padding-top: var(--app-header-offset);
-  margin-top: calc(-1 * var(--app-header-offset) + var(--app-shell-gap));
+  margin-top: 0;
   scroll-padding-top: var(--app-header-offset);
   scrollbar-gutter: stable;
 }
@@ -687,6 +691,26 @@ body {
     gap: 0.75rem;
   }
 
+  .code-display__header {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .code-display__aside {
+    width: 100%;
+    padding-left: 0;
+    border-left: none;
+    border-top: 1px solid rgba(110, 142, 184, 0.35);
+    padding-top: 0.65rem;
+    margin-top: 0.35rem;
+    justify-content: flex-start;
+  }
+
+  .clock {
+    align-items: flex-start;
+    text-align: left;
+  }
+
   .app-header-controls {
     justify-content: flex-start;
     width: 100%;
@@ -727,6 +751,17 @@ body {
 
   .identity-card__code > * {
     width: 100%;
+  }
+
+  .code-display__aside {
+    border-top-color: rgba(110, 142, 184, 0.25);
+    align-items: center;
+    text-align: center;
+  }
+
+  .clock {
+    align-items: center;
+    text-align: center;
   }
 
   .tab-selector {
@@ -830,15 +865,41 @@ a[href^="mailto:"]:hover {
 .code-display {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.55rem;
   text-align: left;
+}
+
+.code-display__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: clamp(0.75rem, 1vw, 1.2rem);
+  width: 100%;
 }
 
 .code-display__meta {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+}
+
+.code-display__previous {
+  font-variant-numeric: tabular-nums;
+}
+
+.code-display__aside {
+  display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
+  padding-left: clamp(0.75rem, 1vw, 1.1rem);
+  border-left: 1px solid rgba(110, 142, 184, 0.35);
   gap: 0.5rem;
+  min-width: 0;
+}
+
+.code-display__code {
+  letter-spacing: 0.08em;
 }
 
 .radar-container {


### PR DESCRIPTION
## Summary
- prevent the main content and contact list from sliding under the sticky header by relying on the computed header offset instead of a negative margin
- allow the rotating code card to render an integrated clock/extra content and tighten the layout so the time sits beside the current code
- refresh styling for the clock and responsive rules so the combined code/time block looks balanced across breakpoints

## Testing
- `npm test -- --runInBand` *(fails: Vitest CLI does not support the flag in this project)*
- `npm test` *(fails: Vitest watch run still reports missing @testing-library/user-event even though it is listed as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d895bbf8832887634f422c029800