### PR TITLE
Handle iframe authentication with modal prompt and compact header

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -37,6 +37,26 @@ contextBridge.exposeInMainWorld('nocListAPI', {
   },
 
   /**
+   * Listen for authentication challenges that require user credentials.
+   * @param {(payload: any) => void} callback
+   */
+  onAuthChallenge: (callback) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+    const channel = 'auth-challenge'
+    const handler = (_event, payload) => callback(payload)
+    ipcRenderer.on(channel, handler)
+    return () => ipcRenderer.off(channel, handler)
+  },
+
+  /**
+   * Provide credentials or cancel an authentication request.
+   * @param {{id: number, username?: string, password?: string, cancel?: boolean}} payload
+   */
+  provideAuthCredentials: (payload) => ipcRenderer.invoke('auth-provide-credentials', payload),
+
+  /**
    * Open an external URL in the user's default browser.
    * @param {string} url
    */

--- a/src/components/AuthPrompt.jsx
+++ b/src/components/AuthPrompt.jsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useMemo, useRef, useState, memo } from 'react'
+
+const getHostLabel = (challenge) => {
+  if (!challenge) return ''
+
+  if (challenge.host) {
+    const port =
+      typeof challenge.port === 'number' && challenge.port > 0 && challenge.port !== 80 && challenge.port !== 443
+        ? `:${challenge.port}`
+        : ''
+    return `${challenge.host}${port}`
+  }
+
+  if (challenge.url) {
+    try {
+      return new URL(challenge.url).host
+    } catch {
+      return challenge.url
+    }
+  }
+
+  return ''
+}
+
+const AuthPrompt = ({ challenge, submitting, onSubmit, onCancel }) => {
+  const [username, setUsername] = useState(challenge?.usernameHint || challenge?.username || '')
+  const [password, setPassword] = useState('')
+  const usernameRef = useRef(null)
+  const passwordRef = useRef(null)
+
+  useEffect(() => {
+    setUsername(challenge?.usernameHint || challenge?.username || '')
+    setPassword('')
+  }, [challenge?.id, challenge?.username, challenge?.usernameHint])
+
+  useEffect(() => {
+    if (!challenge) return undefined
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCancel()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [challenge, onCancel])
+
+  useEffect(() => {
+    if (!challenge) return undefined
+
+    const focusTimer = setTimeout(() => {
+      const target = usernameRef.current || passwordRef.current
+      target?.focus()
+      target?.select?.()
+    }, 40)
+
+    return () => clearTimeout(focusTimer)
+  }, [challenge])
+
+  const hostLabel = useMemo(() => getHostLabel(challenge), [challenge])
+
+  const schemeLabel = challenge?.scheme ? challenge.scheme.toUpperCase() : ''
+
+  const showFailure = (challenge?.previousFailureCount || 0) > 0
+
+  const disableSubmit = submitting || !username.trim() || !password
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    if (disableSubmit) return
+
+    onSubmit({ username: username.trim(), password })
+  }
+
+  return (
+    <div className="auth-modal" role="dialog" aria-modal="true" aria-labelledby="auth-modal-title">
+      <div className="auth-modal__backdrop" />
+      <div className="auth-modal__card">
+        <h2 id="auth-modal-title" className="auth-modal__title">
+          Sign in to continue
+        </h2>
+        <p className="auth-modal__description">
+          {challenge?.realm ? (
+            <>
+              The site <span className="auth-modal__host">{challenge.realm}</span>
+              {hostLabel ? <span> ({hostLabel})</span> : null} requires your credentials.
+            </>
+          ) : (
+            <>
+              {hostLabel ? <span className="auth-modal__host">{hostLabel}</span> : 'This site'} is requesting credentials.
+            </>
+          )}
+        </p>
+        {schemeLabel ? (
+          <p className="auth-modal__meta">
+            Authentication type: <span>{schemeLabel}</span>
+          </p>
+        ) : null}
+        {showFailure ? (
+          <div className="auth-modal__error" role="alert">
+            Sign-in failed. Double-check your username and password.
+          </div>
+        ) : null}
+        <form className="auth-modal__form" onSubmit={handleSubmit} autoComplete="off">
+          <div className="auth-modal__field">
+            <label htmlFor="auth-username">Username</label>
+            <input
+              id="auth-username"
+              ref={usernameRef}
+              type="text"
+              className="auth-modal__input"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              autoComplete="username"
+              disabled={submitting}
+            />
+          </div>
+          <div className="auth-modal__field">
+            <label htmlFor="auth-password">Password</label>
+            <input
+              id="auth-password"
+              ref={passwordRef}
+              type="password"
+              className="auth-modal__input"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              disabled={submitting}
+            />
+          </div>
+          <div className="auth-modal__actions">
+            <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={submitting}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-accent" disabled={disableSubmit}>
+              {submitting ? 'Signing in…' : 'Sign in'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default memo(AuthPrompt)

--- a/src/theme.css
+++ b/src/theme.css
@@ -68,11 +68,14 @@ body {
 
 .app-header-card {
   position: relative;
-  padding: clamp(0.75rem, 0.9vw + 0.5rem, 1.15rem);
+  padding: clamp(0.65rem, 0.85vw + 0.45rem, 1.05rem);
   border-radius: 18px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 0.9vw, 1rem);
 }
 
 .app-header-card::after {
@@ -82,9 +85,9 @@ body {
 
 .app-header-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 1fr);
-  align-items: stretch;
-  gap: clamp(0.75rem, 1vw, 1.25rem);
+  grid-template-columns: minmax(0, 1.35fr) minmax(240px, 1fr);
+  align-items: center;
+  gap: clamp(0.75rem, 1vw, 1rem);
   width: 100%;
 }
 
@@ -180,19 +183,21 @@ body {
 }
 
 
-.app-header-controls {
-  display: flex;
-  flex-wrap: wrap;
+.app-header-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: flex-start;
-  gap: clamp(0.55rem, 0.9vw, 0.85rem);
+  gap: clamp(0.45rem, 0.8vw, 0.9rem);
   min-width: 0;
   width: 100%;
 }
 
-.app-header-controls .tab-selector {
-  flex: 1 1 260px;
-  min-width: min(100%, 320px);
+.app-header-actions .tab-selector {
+  min-width: 0;
+}
+
+.app-header-actions .app-toolbar {
+  justify-self: end;
 }
 
 @media (max-width: 1180px) {
@@ -200,22 +205,17 @@ body {
     grid-template-columns: 1fr;
     gap: clamp(0.6rem, 1.2vw, 1rem);
   }
-
-  .app-header-controls {
-    justify-content: flex-start;
-    align-items: flex-start;
-    row-gap: 0.5rem;
-  }
 }
 
 .app-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  flex-wrap: nowrap;
   min-width: 0;
   font-size: 0.82rem;
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .app-toolbar--hidden {
@@ -387,6 +387,11 @@ body {
 
 .btn.btn-outline:disabled {
   opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn:disabled {
+  opacity: 0.6;
   cursor: not-allowed;
 }
 
@@ -652,6 +657,146 @@ body {
   color: var(--text-light);
 }
 
+.auth-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.25rem, 2vw, 2.75rem);
+  z-index: 2000;
+}
+
+.auth-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 8, 15, 0.78);
+  backdrop-filter: blur(8px);
+}
+
+.auth-modal__card {
+  position: relative;
+  width: min(420px, 92vw);
+  background: var(--bg-elevated);
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-lg);
+  padding: clamp(1.2rem, 1.4vw + 0.75rem, 1.85rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  z-index: 1;
+}
+
+.auth-modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.auth-modal__description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.auth-modal__host {
+  color: var(--text-light);
+  font-weight: 600;
+}
+
+.auth-modal__meta {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.auth-modal__meta span {
+  color: var(--text-light);
+  font-weight: 600;
+}
+
+.auth-modal__error {
+  background: rgba(244, 114, 114, 0.12);
+  border: 1px solid rgba(244, 114, 114, 0.35);
+  color: #f7c8c8;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  font-size: 0.86rem;
+}
+
+.auth-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.auth-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.auth-modal__field label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.auth-modal__input {
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid rgba(110, 142, 184, 0.45);
+  background: rgba(10, 16, 24, 0.85);
+  color: var(--text-light);
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-modal__input:focus {
+  outline: none;
+  border-color: rgba(76, 139, 245, 0.65);
+  box-shadow: var(--glow-accent);
+}
+
+.auth-modal__input:disabled {
+  opacity: 0.65;
+}
+
+.auth-modal__actions {
+  margin-top: 0.35rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@media (max-width: 540px) {
+  .auth-modal {
+    padding: 1.25rem;
+  }
+
+  .auth-modal__card {
+    width: min(100%, 360px);
+    padding: 1.1rem 1.25rem;
+  }
+
+  .auth-modal__actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .auth-modal__actions .btn {
+    width: 100%;
+  }
+}
+
 .text-center { text-align: center; }
 .line-tight { line-height: 1.2; }
 .large-bold { font-size: 1.3rem; font-weight: 700; }
@@ -711,14 +856,14 @@ body {
     text-align: left;
   }
 
-  .app-header-controls {
-    justify-content: flex-start;
-    width: 100%;
-    margin-left: 0;
+  .app-header-actions {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
   }
 
-  .app-header-controls .tab-selector {
-    margin-right: 0;
+  .app-header-actions .app-toolbar {
+    justify-self: stretch;
+    justify-content: flex-start;
   }
 
   .app-toolbar {


### PR DESCRIPTION
## Summary
- intercept Electron authentication challenges, track pending callbacks, and surface them to the renderer for credential entry
- expose authentication IPC helpers in the preload script and mount a reusable AuthPrompt modal in the React app to submit or cancel credentials
- streamline the header layout and add supporting styles so the tab strip and actions sit in a single row while styling the new authentication modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5e0633efc8328a5e8262b81a47368