### PR TITLE
Align header identity row and inline refresh controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -266,36 +266,34 @@ function App() {
                   </div>
                 )}
               </div>
-              <div className="identity-card__content">
-                <div className="identity-card__code">
-                  <CodeDisplay
-                    currentCode={currentCode}
-                    previousCode={previousCode}
-                    progressKey={progressKey}
-                    intervalMs={intervalMs}
+              <div className="identity-card__code">
+                <CodeDisplay
+                  currentCode={currentCode}
+                  previousCode={previousCode}
+                  progressKey={progressKey}
+                  intervalMs={intervalMs}
+                />
+              </div>
+              <div className="identity-card__meta">
+                <Clock />
+                <div
+                  className={`identity-card__refresh${tab === 'radar' ? ' identity-card__refresh--hidden' : ''}`}
+                  aria-hidden={tab === 'radar'}
+                >
+                  <button
+                    onClick={refreshData}
+                    className="btn btn-ghost"
+                    tabIndex={tab === 'radar' ? -1 : undefined}
                   >
-                    <Clock />
-                  </CodeDisplay>
+                    Refresh
+                  </button>
+                  <span className="identity-card__timestamp">Updated {lastRefresh}</span>
                 </div>
               </div>
             </div>
 
             <div className="app-header-actions">
               <TabSelector tab={tab} setTab={setTab} />
-
-              <div
-                className={`app-toolbar${tab === 'radar' ? ' app-toolbar--hidden' : ''}`}
-                aria-hidden={tab === 'radar'}
-              >
-                <button
-                  onClick={refreshData}
-                  className="btn btn-ghost"
-                  tabIndex={tab === 'radar' ? -1 : undefined}
-                >
-                  Refresh
-                </button>
-                <span className="app-toolbar-meta">Updated {lastRefresh}</span>
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/CodeDisplay.jsx
+++ b/src/components/CodeDisplay.jsx
@@ -36,15 +36,15 @@ const CodeDisplay = ({ currentCode, previousCode, progressKey, intervalMs, child
 
   return (
     <div className="code-display">
-      <div className="code-display__header">
+      <div className="code-display__row">
         <div className="code-display__meta">
           <span className="small-text text-muted">Current Code</span>
+          <div className="code-display__value large-bold" aria-live="polite">
+            {currentCode}
+          </div>
           {hasPrevious && <span className="code-display__previous small-muted">Prev: {previousCode}</span>}
         </div>
         {children && <div className="code-display__aside">{children}</div>}
-      </div>
-      <div className="code-display__code large-bold" aria-live="polite">
-        {currentCode}
       </div>
       <div
         className="progress-container"

--- a/src/theme.css
+++ b/src/theme.css
@@ -93,9 +93,10 @@ body {
 
 .identity-card {
   flex: 1 1 360px;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: clamp(0.6rem, 0.85vw, 0.95rem);
+  gap: clamp(0.6rem, 0.85vw, 1.05rem);
   padding: clamp(0.55rem, 0.8vw, 0.9rem) clamp(0.7rem, 1vw, 1rem);
   border-radius: 14px;
   border: 1px solid rgba(110, 142, 184, 0.45);
@@ -144,30 +145,45 @@ body {
   opacity: 0.78;
 }
 
-.identity-card__content {
-  flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
-  gap: clamp(0.5rem, 0.75vw, 0.9rem);
+.identity-card__code {
   min-width: 0;
 }
 
-.identity-card__code {
-  min-width: 0;
+.identity-card__meta {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(0.6rem, 0.85vw, 1rem);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.identity-card__refresh {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  white-space: nowrap;
+}
+
+.identity-card__refresh--hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.identity-card__timestamp {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .clock {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 0.2rem;
   line-height: 1.2;
-  text-align: right;
+  text-align: left;
   min-width: 0;
 }
 
@@ -184,20 +200,15 @@ body {
 
 
 .app-header-actions {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
-  gap: clamp(0.45rem, 0.8vw, 0.9rem);
+  justify-content: flex-end;
   min-width: 0;
   width: 100%;
 }
 
 .app-header-actions .tab-selector {
   min-width: 0;
-}
-
-.app-header-actions .app-toolbar {
-  justify-self: end;
 }
 
 @media (max-width: 1180px) {
@@ -207,28 +218,6 @@ body {
   }
 }
 
-.app-toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.45rem;
-  flex-wrap: nowrap;
-  min-width: 0;
-  font-size: 0.82rem;
-  margin-left: 0;
-}
-
-.app-toolbar--hidden {
-  visibility: hidden;
-  pointer-events: none;
-}
-
-.app-toolbar-meta {
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
 
 .app-main {
   flex: 1 1 auto;
@@ -825,18 +814,26 @@ body {
 
 @media (max-width: 900px) {
   .identity-card {
-    flex: 1 1 100%;
-    flex-direction: column;
-    align-items: stretch;
-    text-align: left;
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: stretch;
+    gap: 0.85rem;
   }
 
-  .identity-card__content {
-    flex-direction: column;
-    gap: 0.75rem;
+  .identity-card__figure {
+    justify-self: center;
   }
 
-  .code-display__header {
+  .identity-card__meta {
+    justify-content: space-between;
+  }
+
+  .identity-card__refresh {
+    flex: 1 1 auto;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .code-display__row {
     grid-template-columns: 1fr;
     gap: 0.65rem;
   }
@@ -851,51 +848,44 @@ body {
     justify-content: flex-start;
   }
 
-  .clock {
-    align-items: flex-start;
-    text-align: left;
-  }
-
   .app-header-actions {
-    grid-template-columns: 1fr;
-    gap: 0.6rem;
-  }
-
-  .app-header-actions .app-toolbar {
-    justify-self: stretch;
     justify-content: flex-start;
-  }
-
-  .app-toolbar {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    margin-left: 0;
-  }
-
-  .app-toolbar-meta {
-    font-size: 0.78rem;
   }
 }
 
 @media (max-width: 640px) {
   .identity-card {
     text-align: center;
-    align-items: center;
+    gap: 0.75rem;
   }
 
-  .identity-card__content {
-    width: 100%;
-    align-items: center;
+  .identity-card__figure {
+    justify-self: center;
   }
 
-  .identity-card__code {
-    width: 100%;
+  .identity-card__meta {
+    flex-direction: column;
     align-items: center;
+    gap: 0.65rem;
+  }
+
+  .identity-card__refresh {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+    white-space: normal;
+  }
+
+  .identity-card__timestamp {
     text-align: center;
   }
 
-  .identity-card__code > * {
-    width: 100%;
+  .code-display__row {
+    text-align: center;
+  }
+
+  .code-display__meta {
+    align-items: center;
   }
 
   .code-display__aside {
@@ -1014,7 +1004,7 @@ a[href^="mailto:"]:hover {
   text-align: left;
 }
 
-.code-display__header {
+.code-display__row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
@@ -1024,9 +1014,9 @@ a[href^="mailto:"]:hover {
 
 .code-display__meta {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.15rem;
+  align-items: baseline;
+  gap: clamp(0.35rem, 0.6vw, 0.75rem);
+  flex-wrap: wrap;
 }
 
 .code-display__previous {
@@ -1043,7 +1033,7 @@ a[href^="mailto:"]:hover {
   min-width: 0;
 }
 
-.code-display__code {
+.code-display__value {
   letter-spacing: 0.08em;
 }
 


### PR DESCRIPTION
## Summary
- restructure the app header so the logo, code display, clock, and refresh controls share a single horizontal row
- simplify the rotating code component markup to keep the code value inline with its label while retaining the progress bar
- update header and code display styling for the new layout, including responsive adjustments and inline refresh metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e8a78828832891d2e55054db5371