### PR TITLE
Fix Windows CI by updating App branding test expectation

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -17,53 +17,33 @@ vi.mock('./components/ContactSearch', () => ({
 
 import App from './App'
 
-let originalFetch
 let originalNocListAPI
 
 beforeEach(() => {
-  originalFetch = global.fetch
   originalNocListAPI = window.nocListAPI
   localStorage.clear()
 })
 
 afterEach(() => {
-  global.fetch = originalFetch
   window.nocListAPI = originalNocListAPI
 })
 
 describe('App', () => {
-  it('renders fallback branding when logo is unavailable', () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
-    )
+  it('renders application branding in the header', () => {
     window.nocListAPI = {
       loadExcelData: async () => ({ emailData: [], contactData: [] }),
       onExcelDataUpdate: () => () => {},
       onExcelWatchError: () => () => {},
     }
-    render(<App />)
-    expect(screen.getByLabelText(/noc list logo/i)).toBeInTheDocument()
-  })
 
-  it('shows image when logo file is available', async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
-    )
-    window.nocListAPI = {
-      loadExcelData: async () => ({ emailData: [], contactData: [] }),
-      onExcelDataUpdate: () => () => {},
-      onExcelWatchError: () => () => {},
-    }
     render(<App />)
-    expect(await screen.findByAltText(/noc list logo/i)).toBeInTheDocument()
-})
+
+    expect(screen.getByLabelText(/noc toolkit/i)).toBeInTheDocument()
+    expect(screen.getByText(/noc toolkit/i)).toBeInTheDocument()
+  })
 
   it('adds a contact email to the ad-hoc list from contact search', async () => {
     const user = userEvent.setup()
-
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
-    )
 
     const loadExcelData = vi.fn().mockResolvedValue({
       emailData: [


### PR DESCRIPTION
## Summary
- update the App component tests to assert the current header branding instead of a removed logo asset
- simplify the test setup by dropping unused global fetch mocks

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d6fa7fd94c832887de67395d1d885c