### PR TITLE
Improve UI responsiveness by reducing redundant work

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -96,25 +96,23 @@ function App() {
         return 'invalid'
       }
 
-      /** @type {'added' | 'duplicate'} */
-      let status = 'duplicate'
+      const alreadyExists = adhocEmails.some(
+        (existing) => existing.toLowerCase() === normalized,
+      )
 
-      setAdhocEmails((prev) => {
-        if (prev.some((existing) => existing.toLowerCase() === normalized)) {
-          return prev
-        }
+      if (alreadyExists) {
+        return 'duplicate'
+      }
 
-        status = 'added'
-        return [...prev, cleaned]
-      })
+      setAdhocEmails((prev) => [...prev, cleaned])
 
-      if (status === 'added' && switchToEmailTab) {
+      if (switchToEmailTab) {
         setTab('email')
       }
 
-      return status
+      return 'added'
     },
-    [isValidEmail, setTab],
+    [adhocEmails, isValidEmail, setTab],
   )
 
   useLayoutEffect(() => {

--- a/src/components/CodeDisplay.test.jsx
+++ b/src/components/CodeDisplay.test.jsx
@@ -65,7 +65,7 @@ describe('CodeDisplay progress', () => {
     )
     expect(progress).toHaveAttribute('aria-valuenow', '0')
     act(() => {
-      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(300)
     })
     expect(Number(progress.getAttribute('aria-valuenow'))).toBeGreaterThan(0)
     vi.useRealTimers()

--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -96,6 +96,7 @@ const EmailGroups = ({
         email: findEmailAddress(contact),
         initials: getContactInitials(contact?.Name),
         phone: phoneValue,
+        formattedPhone: formatPhones(phoneValue),
         searchText: Object.values(contact)
           .map((value) => (value == null ? '' : String(value)))
           .join(' ')
@@ -471,7 +472,7 @@ const EmailGroups = ({
                       </div>
                       <div>
                         <span className="label">Phone</span>
-                        <span>{formatPhones(contact.phone) || 'Not available'}</span>
+                        <span>{contact.formattedPhone || 'Not available'}</span>
                       </div>
                     </div>
                     <div className="contact-picker__actions">


### PR DESCRIPTION
## Summary
- throttle the code display progress updates to a low-frequency interval to cut renderer work
- pre-compute contact metadata so search and picker UIs reuse email, initials, and phone formatting
- ensure ad-hoc additions only recompute when the list changes and reuse formatted phone data in the email overlay

## Testing
- npm test --silent -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d6fef561d083288258c8a920f1f0c9