### PR TITLE
Fix adhoc email addition race condition

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -96,23 +96,28 @@ function App() {
         return 'invalid'
       }
 
-      const alreadyExists = adhocEmails.some(
-        (existing) => existing.toLowerCase() === normalized,
-      )
+      let status = 'added'
 
-      if (alreadyExists) {
-        return 'duplicate'
-      }
+      setAdhocEmails((prev) => {
+        const alreadyExists = prev.some(
+          (existing) => existing.toLowerCase() === normalized,
+        )
 
-      setAdhocEmails((prev) => [...prev, cleaned])
+        if (alreadyExists) {
+          status = 'duplicate'
+          return prev
+        }
 
-      if (switchToEmailTab) {
+        return [...prev, cleaned]
+      })
+
+      if (status === 'added' && switchToEmailTab) {
         setTab('email')
       }
 
-      return 'added'
+      return status
     },
-    [adhocEmails, isValidEmail, setTab],
+    [isValidEmail, setTab],
   )
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- update addAdhocEmail to dedupe inside the state updater so concurrent calls cannot add duplicates
- ensure the tab only changes when a new address is actually added

## Testing
- npm test -- --run *(fails: Missing dependency @testing-library/user-event)*

------
https://chatgpt.com/codex/tasks/task_e_68d7070448c883289f6d9cc0a7603462