### PR TITLE
Virtualize contact search and expand picker results

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -107,10 +107,9 @@ const EmailGroups = ({
 
   const filteredContacts = useMemo(() => {
     const term = contactQuery.trim().toLowerCase()
-    const list = term
+    return term
       ? indexedContacts.filter((contact) => contact.searchText.includes(term))
       : indexedContacts
-    return list.slice(0, 250)
   }, [contactQuery, indexedContacts])
 
   const groupMap = useMemo(
@@ -496,9 +495,15 @@ const EmailGroups = ({
                 <div className="empty-state">No contacts match your search.</div>
               )}
             </div>
-            {!contactQuery && indexedContacts.length > filteredContacts.length && (
+            {indexedContacts.length > filteredContacts.length && (
               <p className="small-muted m-0">
-                Showing the first {filteredContacts.length} contacts. Use search to find others.
+                Showing the first {filteredContacts.length.toLocaleString()} contacts. Use search to
+                find others.
+              </p>
+            )}
+            {contactQuery && filteredContacts.length > 0 && indexedContacts.length === filteredContacts.length && (
+              <p className="small-muted m-0">
+                Found {filteredContacts.length.toLocaleString()} matching contacts.
               </p>
             )}
           </div>

--- a/src/theme.css
+++ b/src/theme.css
@@ -1114,15 +1114,29 @@ a[href^="mailto:"]:hover {
 }
 
 
-.contact-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: clamp(1rem, 1.6vw, 1.5rem);
-  width: 100%;
-  padding: 0;
-  margin: 0;
+.contact-list-scroll {
   padding-top: var(--contact-header-height);
   margin-top: calc(-1 * var(--contact-header-height));
+  width: 100%;
+  border-radius: 18px;
+}
+
+.contact-list__row {
+  display: grid;
+  grid-template-columns: repeat(var(--contact-columns, 1), minmax(280px, 1fr));
+  gap: clamp(1rem, 1.6vw, 1.5rem);
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.contact-card-wrapper {
+  display: flex;
+  min-width: 0;
+}
+
+.contact-card-wrapper > .contact-card {
+  flex: 1;
 }
 
 .contact-card {


### PR DESCRIPTION
## Summary
- virtualize the contact search grid with react-window, responsive column sizing, and refreshed styling to keep the DOM light
- retain keyboard navigation by tracking active buttons and adjusting tests for the virtualized viewport
- remove the 250-result cap in the email contact picker and surface clearer messaging for large or filtered result sets

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d70922dbf483289c7c39d7d76ebdff