### PR TITLE
Improve contact card layout and enlarge radar iframe

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -383,7 +383,7 @@ body {
 
 .module-card--radar {
   padding: clamp(0.9rem, 2vw, 1.4rem);
-  min-height: 60vh;
+  min-height: clamp(720px, 90vh, 1100px);
 }
 
 .module-card--radar .sticky-header {
@@ -1177,6 +1177,7 @@ a[href^="mailto:"]:hover {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-height: clamp(640px, 88vh, 1040px);
 }
 
 
@@ -1188,6 +1189,7 @@ a[href^="mailto:"]:hover {
   background: var(--surface-raised);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
+  min-height: clamp(680px, 88vh, 1080px);
 }
 
 .radar-frame {
@@ -1216,16 +1218,18 @@ a[href^="mailto:"]:hover {
 
 .contact-list__row {
   display: grid;
-  grid-template-columns: repeat(var(--contact-columns, 1), minmax(280px, 1fr));
+  grid-template-columns: repeat(var(--contact-columns, 1), minmax(320px, 1fr));
   gap: clamp(1rem, 1.6vw, 1.5rem);
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+  align-items: stretch;
 }
 
 .contact-card-wrapper {
   display: flex;
   min-width: 0;
+  height: 100%;
 }
 
 .contact-card-wrapper > .contact-card {


### PR DESCRIPTION
## Summary
- improve virtualized contact row measurement to prevent overlapping cards
- raise the dispatcher radar module and iframe minimum heights to extend the view vertically

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d72c3f913c83288fda1161a4f9ed2f