### PR TITLE
Fix contact search crash and stabilize Excel updates

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -3,6 +3,13 @@ const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('nocListAPI', {
   loadExcelData: () => ipcRenderer.sendSync('load-excel-data'),
   openFile: (filename) => ipcRenderer.send('open-excel-file', filename),
-  onExcelDataUpdate: (callback) => ipcRenderer.on('excel-data-updated', (_, data) => callback(data)),
+  onExcelDataUpdate: (callback) => {
+    if (typeof callback !== 'function') return () => {}
+
+    const listener = (_event, data) => callback(data)
+    ipcRenderer.on('excel-data-updated', listener)
+
+    return () => ipcRenderer.removeListener('excel-data-updated', listener)
+  },
   openExternal: (url) => ipcRenderer.invoke('open-external-link', url)
 })

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -19,14 +19,21 @@ const formatPhones = (value) => {
 
 const ContactSearch = ({ contactData, addAdhocEmail }) => {
   const [query, setQuery] = useState('')
+  const contacts = useMemo(
+    () => (Array.isArray(contactData) ? contactData : []),
+    [contactData]
+  )
+
   const filtered = useMemo(
     () =>
-      contactData.filter(c =>
-        Object.values(c).some(val =>
-          String(val).toLowerCase().includes(query.toLowerCase())
+      contacts.filter(contact =>
+        contact &&
+        typeof contact === 'object' &&
+        Object.values(contact).some(val =>
+          String(val ?? '').toLowerCase().includes(query.toLowerCase())
         )
       ),
-    [query, contactData]
+    [query, contacts]
   )
 
   return (


### PR DESCRIPTION
## Summary
- guard access to preload Excel APIs and expose an unsubscribe hook for file watchers
- sanitize Excel payloads before use and refactor the rotating code timer to avoid runaway re-renders
- harden contact search filtering so missing or malformed contact rows no longer crash the UI

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d73f2cba908328b42b0a43690ad12e