### PR TITLE
Gracefully handle malformed contact rows

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -53,26 +53,34 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
     )
   }, [])
 
-  const indexedContacts = useMemo(
-    () =>
-      contactData.map((contact, index) => {
-        const values = Object.values(contact).map((value) =>
-          value == null ? '' : String(value),
-        )
-        const searchText = values.join(' ').toLowerCase()
-        const emailAddress = findEmailAddress(contact)
+  const indexedContacts = useMemo(() => {
+    if (!Array.isArray(contactData)) {
+      return []
+    }
 
-        return {
-          raw: contact,
-          key: getContactKey(contact, index),
-          emailAddress,
-          initials: getContactInitials(contact?.Name),
-          formattedPhone: formatPhones(contact?.Phone),
-          searchText,
-        }
-      }),
-    [contactData, getContactKey],
-  )
+    return contactData.reduce((acc, contact, index) => {
+      if (!contact || typeof contact !== 'object') {
+        return acc
+      }
+
+      const values = Object.values(contact).map((value) =>
+        value == null ? '' : String(value),
+      )
+      const searchText = values.join(' ').toLowerCase()
+      const emailAddress = findEmailAddress(contact)
+
+      acc.push({
+        raw: contact,
+        key: getContactKey(contact, index),
+        emailAddress,
+        initials: getContactInitials(contact?.Name),
+        formattedPhone: formatPhones(contact?.Phone),
+        searchText,
+      })
+
+      return acc
+    }, [])
+  }, [contactData, getContactKey])
 
   const filtered = useMemo(() => {
     const q = deferredQuery.trim().toLowerCase()

--- a/src/components/ContactSearch.test.jsx
+++ b/src/components/ContactSearch.test.jsx
@@ -13,9 +13,11 @@ const contacts = Array.from({ length: 20 }, (_, i) => ({
 afterEach(() => cleanup())
 
 describe('ContactSearch', () => {
-  it('filters contacts without crashing on non-string values', () => {
+  it('filters contacts without crashing on malformed entries', () => {
+    const mixedContacts = [...contacts, null, undefined, 42, 'invalid']
+
     render(
-      <ContactSearch contactData={contacts} addAdhocEmail={() => 'added'} />
+      <ContactSearch contactData={mixedContacts} addAdhocEmail={() => 'added'} />
     )
     const input = screen.getByPlaceholderText(/search contacts/i)
     fireEvent.change(input, { target: { value: 'Agent 1' } })


### PR DESCRIPTION
## Summary
- guard the contact list indexing logic against null or non-object rows returned from Excel parsing
- update the contact search test suite to cover malformed contact inputs

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68d744bae5b8832891a6e71fd1f5e66a