### PR TITLE
Align macOS icon handling with workflow packaging

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,26 @@
+name: macOS Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test
+      - run: node scripts/manage-mac-icon.mjs
+      - run: npm run package:mac
+      - run: node scripts/manage-mac-icon.mjs cleanup
+        if: always()
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NOCList-darwin-arm64
+          path: release/NOCList-darwin-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+public/icon.icns
+release/

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@vitejs/plugin-react": "^4.0.0",
         "electron-packager": "^17.1.2",
         "jsdom": "^26.1.0",
+        "png2icons": "^2.0.1",
         "vite": "^5.0.0",
         "vitest": "^3.2.2"
       }
@@ -4105,6 +4106,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/png2icons": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/png2icons/-/png2icons-2.0.1.tgz",
+      "integrity": "sha512-GDEQJr8OG4e6JMp7mABtXFSEpgJa1CCpbQiAR+EjhkHJHnUL9zPPtbOrjsMD8gUbikgv3j7x404b0YJsV3aVFA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "png2icons": "png2icons-cli.js"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true",
+    "package:mac": "npm run build && electron-packager . NOCList --platform=darwin --arch=arm64 --overwrite --out=release --icon=public/icon.icns"
   },
   "dependencies": {
     "chokidar": "^3.6.0",
@@ -23,6 +24,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.0.0",
     "electron-packager": "^17.1.2",
+    "png2icons": "^2.0.1",
     "jsdom": "^26.1.0",
     "vite": "^5.0.0",
     "vitest": "^3.2.2"

--- a/scripts/manage-mac-icon.mjs
+++ b/scripts/manage-mac-icon.mjs
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import png2icons from 'png2icons';
+
+const { createICNS, BICUBIC } = png2icons;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+const iconSource = join(projectRoot, 'public', 'icon.png');
+const iconTarget = join(projectRoot, 'public', 'icon.icns');
+
+function generateIcon() {
+  if (existsSync(iconTarget)) {
+    return;
+  }
+
+  if (!existsSync(iconSource)) {
+    throw new Error('Unable to locate public/icon.png to generate a macOS icon.');
+  }
+
+  const pngBuffer = readFileSync(iconSource);
+  const icnsBuffer = createICNS(pngBuffer, BICUBIC, 0);
+
+  if (!icnsBuffer) {
+    throw new Error('Failed to convert icon.png into icon.icns.');
+  }
+
+  writeFileSync(iconTarget, icnsBuffer);
+}
+
+function cleanupIcon() {
+  if (existsSync(iconTarget)) {
+    rmSync(iconTarget);
+  }
+}
+
+try {
+  const action = process.argv[2] ?? 'generate';
+
+  if (action === 'cleanup') {
+    cleanupIcon();
+  } else if (action === 'generate') {
+    generateIcon();
+  } else {
+    throw new Error(`Unknown action "${action}". Expected "generate" or "cleanup".`);
+  }
+} catch (error) {
+  console.error(error.message || error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- update the macOS package script to run the direct electron-packager command with the generated .icns icon
- invoke the macOS icon generator within the GitHub Actions workflow before packaging and clean it up afterward
- retain the helper that produces the temporary macOS icon so no binary assets are committed

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d8cd136b708328971d33223e485749