### PR TITLE
Add macOS packaging helper script for build workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,23 @@
+name: macOS Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test
+      - run: npm run package:mac
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NOCList-darwin-arm64
+          path: release/NOCList-darwin-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+public/icon.icns
+release/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true",
+    "package:mac": "node scripts/package-mac.mjs"
   },
   "dependencies": {
     "chokidar": "^3.6.0",

--- a/scripts/manage-mac-icon.mjs
+++ b/scripts/manage-mac-icon.mjs
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+const iconSource = join(projectRoot, 'public', 'icon.png');
+const iconTarget = join(projectRoot, 'public', 'icon.icns');
+
+const iconSetName = 'icon.iconset';
+
+const iconSizes = [
+  { size: 16, retina: false },
+  { size: 16, retina: true },
+  { size: 32, retina: false },
+  { size: 32, retina: true },
+  { size: 64, retina: false },
+  { size: 64, retina: true },
+  { size: 128, retina: false },
+  { size: 128, retina: true },
+  { size: 256, retina: false },
+  { size: 256, retina: true },
+  { size: 512, retina: false },
+  { size: 512, retina: true }
+];
+
+function ensureMacOS() {
+  if (process.platform !== 'darwin') {
+    throw new Error('Generating a macOS icon requires running on macOS.');
+  }
+}
+
+function generateIcon() {
+  if (existsSync(iconTarget)) {
+    return;
+  }
+
+  ensureMacOS();
+
+  if (!existsSync(iconSource)) {
+    throw new Error('Unable to locate public/icon.png to generate a macOS icon.');
+  }
+
+  const tempRoot = mkdtempSync(join(tmpdir(), 'noclist-icon-'));
+  const iconsetDir = join(tempRoot, iconSetName);
+  mkdirSync(iconsetDir);
+
+  try {
+    for (const { size, retina } of iconSizes) {
+      const dimension = retina ? size * 2 : size;
+      const suffix = retina ? '@2x' : '';
+      const target = join(iconsetDir, `icon_${size}x${size}${suffix}.png`);
+
+      execFileSync('sips', ['-z', `${dimension}`, `${dimension}`, iconSource, '--out', target]);
+    }
+
+    execFileSync('iconutil', ['--convert', 'icns', '--output', iconTarget, iconsetDir]);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function cleanupIcon() {
+  if (existsSync(iconTarget)) {
+    rmSync(iconTarget);
+  }
+}
+
+try {
+  const action = process.argv[2] ?? 'generate';
+
+  if (action === 'cleanup') {
+    cleanupIcon();
+  } else if (action === 'generate') {
+    generateIcon();
+  } else {
+    throw new Error(`Unknown action "${action}". Expected "generate" or "cleanup".`);
+  }
+} catch (error) {
+  console.error(error.message || error);
+  process.exitCode = 1;
+}

--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -1,0 +1,67 @@
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+const manageIconScript = join(__dirname, 'manage-mac-icon.mjs');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    cwd: projectRoot,
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    const error = new Error(
+      `Command "${command} ${args.join(' ')}" failed with exit code ${result.status ?? 'null'}.`
+    );
+    error.status = result.status ?? 1;
+    throw error;
+  }
+}
+
+function resolveExecutable(basePath) {
+  if (process.platform === 'win32') {
+    return `${basePath}.cmd`;
+  }
+
+  return basePath;
+}
+
+const electronPackagerBin = resolveExecutable(
+  join(projectRoot, 'node_modules', '.bin', 'electron-packager')
+);
+
+let exitCode = 0;
+
+try {
+  run('npm', ['run', 'build']);
+  run('node', [manageIconScript]);
+
+  run(electronPackagerBin, [
+    '.',
+    'NOCList',
+    '--platform=darwin',
+    '--arch=arm64',
+    '--overwrite',
+    '--out=release',
+    '--icon=public/icon.icns',
+    '--asar',
+    '--prune=true',
+  ]);
+} catch (error) {
+  exitCode = error.status ?? 1;
+  console.error(error.message || error);
+} finally {
+  try {
+    run('node', [manageIconScript, 'cleanup']);
+  } catch (cleanupError) {
+    exitCode = exitCode || cleanupError.status || 1;
+    console.error(cleanupError.message || cleanupError);
+  }
+}
+
+process.exitCode = exitCode;


### PR DESCRIPTION
## Summary
- update the `package:mac` npm script to delegate to a dedicated helper and avoid merge conflicts
- add a macOS packaging helper that builds the app, generates the temporary icon, invokes `electron-packager`, and cleans up afterwards

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d8cd136b708328971d33223e485749