### PR TITLE
Simplify macOS packaging workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,23 @@
+name: macOS Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test -- --run
+      - run: npm run package:mac
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NOCList-darwin-arm64
+          path: release/NOCList-darwin-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+public/icon.icns
+release/

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@vitejs/plugin-react": "^4.0.0",
         "electron-packager": "^17.1.2",
         "jsdom": "^26.1.0",
+        "png2icons": "^2.0.1",
         "vite": "^5.0.0",
         "vitest": "^3.2.2"
       }
@@ -4105,6 +4106,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/png2icons": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/png2icons/-/png2icons-2.0.1.tgz",
+      "integrity": "sha512-GDEQJr8OG4e6JMp7mABtXFSEpgJa1CCpbQiAR+EjhkHJHnUL9zPPtbOrjsMD8gUbikgv3j7x404b0YJsV3aVFA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "png2icons": "png2icons-cli.js"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true"
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true",
+    "prepackage:mac": "node scripts/generate-mac-icon.mjs",
+    "package:mac": "npm run build && electron-packager . NOCList --platform=darwin --arch=arm64 --overwrite --out=release --icon=public/icon.icns --asar --prune=true",
+    "postpackage:mac": "node scripts/generate-mac-icon.mjs cleanup"
   },
   "dependencies": {
     "chokidar": "^3.6.0",
@@ -23,6 +26,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.0.0",
     "electron-packager": "^17.1.2",
+    "png2icons": "^2.0.1",
     "jsdom": "^26.1.0",
     "vite": "^5.0.0",
     "vitest": "^3.2.2"

--- a/scripts/generate-mac-icon.mjs
+++ b/scripts/generate-mac-icon.mjs
@@ -1,0 +1,47 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import png2icons from 'png2icons';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '..');
+const iconPngPath = join(projectRoot, 'public', 'icon.png');
+const iconIcnsPath = join(projectRoot, 'public', 'icon.icns');
+
+async function createIcon() {
+  const source = await fs.readFile(iconPngPath);
+  const icnsBuffer = png2icons.createICNS(source, png2icons.BILINEAR, false);
+
+  if (!icnsBuffer) {
+    throw new Error('Unable to generate macOS icon from public/icon.png');
+  }
+
+  await fs.writeFile(iconIcnsPath, icnsBuffer);
+}
+
+async function removeIcon() {
+  try {
+    await fs.unlink(iconIcnsPath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+async function main() {
+  const shouldCleanup = process.argv[2] === 'cleanup';
+
+  if (shouldCleanup) {
+    await removeIcon();
+    return;
+  }
+
+  await createIcon();
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- update the macOS npm packaging script to run electron-packager directly with lifecycle hooks handling icon generation and cleanup
- add a reusable PNG-to-ICNS converter script and register png2icons as a development dependency
- adjust the macOS GitHub Actions workflow to use the new script sequence while uploading the packaged artifact

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d8cd136b708328971d33223e485749