### PR TITLE
Fix macOS packaging signing identity handling

### DIFF
--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -143,11 +143,15 @@ function main() {
     );
 
     console.log(`Signing macOS app using identity: ${signingIdentity}`);
+    const signingArgs =
+      signingIdentity === '-'
+        ? ['--identity=-']
+        : ['--identity', signingIdentity];
+
     run('npx', [
       'electron-osx-sign',
       appPath,
-      '--identity',
-      signingIdentity
+      ...signingArgs
     ]);
   } catch (error) {
     console.error(error.message || error);


### PR DESCRIPTION
## Summary
- ensure the mac packaging script passes the unsigned identity using the correct flag format
- avoid electron-osx-sign misparsing the identity when using the default placeholder

## Testing
- not run (macOS packaging requires macOS tooling)


------
https://chatgpt.com/codex/tasks/task_e_68db0138fee88328bcb8e5458a4a95a1